### PR TITLE
Resolves #35 dynamic target list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@ hs_err_pid*
 .classpath
 .project
 
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
 # application.yaml for local tests
 application.yaml
 

--- a/src/main/java/org/cloudfoundry/promregator/PromregatorApplication.java
+++ b/src/main/java/org/cloudfoundry/promregator/PromregatorApplication.java
@@ -32,6 +32,8 @@ import io.prometheus.client.hotspot.DefaultExports;
 public class PromregatorApplication {
 	
 	private static final Logger log = Logger.getLogger(PromregatorApplication.class);
+
+	public static final String SPACE_ALL_APPLICATIONS = "SPACE_ALL_APPLICATIONS";
 	
 	public static void main(String[] args) {
 		SpringApplication.run(PromregatorApplication.class, args);

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -23,6 +23,7 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesRequest;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v3.processes.ListProcessesRequest;
 import org.cloudfoundry.client.v3.processes.ListProcessesResponse;
+import org.cloudfoundry.promregator.PromregatorApplication;
 import org.cloudfoundry.promregator.config.ConfigurationException;
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.DefaultConnectionContext;
@@ -39,36 +40,36 @@ import reactor.core.publisher.Mono;
 @Component
 public class ReactiveCFAccessorImpl implements CFAccessor {
 	private static final Logger log = Logger.getLogger(ReactiveCFAccessorImpl.class);
-	
+
 	@Value("${cf.api_host}")
 	private String apiHost;
 
 	@Value("${cf.username}")
 	private String username;
-	
+
 	@Value("${cf.password}")
 	private String password;
-	
+
 	@Value("${cf.skipSslValidation:false}")
 	private boolean skipSSLValidation;
-	
-	@Value("${cf.proxyHost:#{null}}") 
+
+	@Value("${cf.proxyHost:#{null}}")
 	private String proxyHost;
-	
-	@Value("${cf.proxyPort:0}") 
+
+	@Value("${cf.proxyPort:0}")
 	private int proxyPort;
 
 	private static final Pattern PATTERN_HTTP_BASED_PROTOCOL_PREFIX = Pattern.compile("^https?://");
-	
+
 	private ReactorCloudFoundryClient cloudFoundryClient;
-	
+
 	private DefaultConnectionContext connectionContext(ProxyConfiguration proxyConfiguration) throws ConfigurationException {
 		if (apiHost != null && PATTERN_HTTP_BASED_PROTOCOL_PREFIX.matcher(apiHost).find()) {
 			throw new ConfigurationException("cf.api_host configuration parameter must not contain an http(s)://-like prefix; specify the hostname only instead");
 		}
 
 		Builder connctx = DefaultConnectionContext.builder().apiHost(apiHost).skipSslValidation(skipSSLValidation);
-		
+
 		if (proxyConfiguration != null) {
 			connctx = connctx.proxyConfiguration(proxyConfiguration);
 		}
@@ -83,15 +84,15 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 		if (this.proxyHost != null && PATTERN_HTTP_BASED_PROTOCOL_PREFIX.matcher(this.proxyHost).find()) {
 			throw new ConfigurationException("cf.proxyHost configuration parameter must not contain an http(s)://-like prefix; specify the hostname only instead");
 		}
-		
+
 		if (this.proxyHost != null && this.proxyPort != 0) {
-			
+
 			String proxyIP = null;
 			if (!InetAddressUtils.isIPv4Address(this.proxyHost) && !InetAddressUtils.isIPv6Address(this.proxyHost)) {
 				/*
 				 * NB: There is currently a bug in io.netty.util.internal.SocketUtils.connect()
 				 * which is called implicitly by the CF API Client library, which leads to the effect
-				 * that a hostname for the proxy isn't resolved. Thus, it is only possible to pass 
+				 * that a hostname for the proxy isn't resolved. Thus, it is only possible to pass
 				 * IP addresses as proxy names.
 				 * To work around this issue, we manually perform a resolution of the hostname here
 				 * and then feed that one to the CF API Client library...
@@ -106,25 +107,25 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 				// the address specified is already an IP address
 				proxyIP = this.proxyHost;
 			}
-			
+
 			return ProxyConfiguration.builder().host(proxyIP).port(this.proxyPort).build();
-			
+
 		} else {
 			return null;
 		}
 	}
-	
+
 	private ReactorCloudFoundryClient cloudFoundryClient(ConnectionContext connectionContext, TokenProvider tokenProvider) {
 		return ReactorCloudFoundryClient.builder().connectionContext(connectionContext).tokenProvider(tokenProvider).build();
 	}
-	
+
 	@PostConstruct
 	@SuppressWarnings("PMD.UnusedPrivateMethod") // method is really required
 	private void constructCloudFoundryClient() throws ConfigurationException {
 		ProxyConfiguration proxyConfiguration = this.proxyConfiguration();
 		DefaultConnectionContext connectionContext = this.connectionContext(proxyConfiguration);
 		PasswordGrantTokenProvider tokenProvider = this.tokenProvider();
-		
+
 		this.cloudFoundryClient = this.cloudFoundryClient(connectionContext, tokenProvider);
 	}
 
@@ -135,12 +136,12 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	public Mono<ListOrganizationsResponse> retrieveOrgId(String orgName) {
 		ListOrganizationsRequest orgsRequest = ListOrganizationsRequest.builder().name(orgName).build();
 		Mono<ListOrganizationsResponse> monoResp = this.cloudFoundryClient.organizations().list(orgsRequest);
-		
+
 		monoResp = monoResp.log(log.getName()+".retrieveOrgId", Level.FINE);
-		
+
 		return monoResp;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.cloudfoundry.promregator.cfaccessor.CFAccessor#retrieveSpaceId(java.lang.String, java.lang.String)
 	 */
@@ -148,29 +149,30 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	public Mono<ListSpacesResponse> retrieveSpaceId(String orgId, String spaceName) {
 		ListSpacesRequest spacesRequest = ListSpacesRequest.builder().organizationId(orgId).name(spaceName).build();
 		Mono<ListSpacesResponse> monoResp = this.cloudFoundryClient.spaces().list(spacesRequest);
-		
+
 		monoResp = monoResp.log(log.getName()+".retrieveSpaceId", Level.FINE);
-		
+
 		return monoResp;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.cloudfoundry.promregator.cfaccessor.CFAccessor#retrieveApplicationId(java.lang.String, java.lang.String, java.lang.String)
 	 */
 	@Override
 	public Mono<ListApplicationsResponse> retrieveApplicationId(String orgId, String spaceId, String applicationName) {
-		ListApplicationsRequest request = ListApplicationsRequest.builder()
+		ListApplicationsRequest.Builder builder = ListApplicationsRequest.builder()
 				.organizationId(orgId)
-				.spaceId(spaceId)
-				.name(applicationName)
-				.build();
-		Mono<ListApplicationsResponse> monoResp = this.cloudFoundryClient.applicationsV2().list(request);
-		
+				.spaceId(spaceId);
+		if (!PromregatorApplication.SPACE_ALL_APPLICATIONS.equalsIgnoreCase(applicationName)) {
+			builder.name(applicationName);
+		}
+		Mono<ListApplicationsResponse> monoResp = this.cloudFoundryClient.applicationsV2().list(builder.build());
+
 		monoResp = monoResp.log(log.getName()+".retrieveApplicationId", Level.FINE);
-		
+
 		return monoResp;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.cloudfoundry.promregator.cfaccessor.CFAccessor#retrieveRouteMapping(java.lang.String)
 	 */
@@ -178,12 +180,12 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	public Mono<ListRouteMappingsResponse> retrieveRouteMapping(String appId) {
 		ListRouteMappingsRequest mappingRequest = ListRouteMappingsRequest.builder().applicationId(appId).build();
 		Mono<ListRouteMappingsResponse> monoResp = this.cloudFoundryClient.routeMappings().list(mappingRequest);
-		
+
 		monoResp = monoResp.log(log.getName()+".retrieveRouteMapping", Level.FINE);
-		
+
 		return monoResp;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.cloudfoundry.promregator.cfaccessor.CFAccessor#retrieveRoute(java.lang.String)
 	 */
@@ -191,12 +193,12 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	public Mono<GetRouteResponse> retrieveRoute(String routeId) {
 		GetRouteRequest getRequest = GetRouteRequest.builder().routeId(routeId).build();
 		Mono<GetRouteResponse> monoResp = this.cloudFoundryClient.routes().get(getRequest).log();
-		
+
 		monoResp = monoResp.log(log.getName()+".retrieveRoute", Level.FINE);
-		
+
 		return monoResp;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.cloudfoundry.promregator.cfaccessor.CFAccessor#retrieveSharedDomain(java.lang.String)
 	 */
@@ -204,12 +206,12 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	public Mono<GetSharedDomainResponse> retrieveSharedDomain(String domainId) {
 		GetSharedDomainRequest domainRequest = GetSharedDomainRequest.builder().sharedDomainId(domainId).build();
 		Mono<GetSharedDomainResponse> monoResp = this.cloudFoundryClient.sharedDomains().get(domainRequest).log();
-		
+
 		monoResp = monoResp.log(log.getName()+".retrieveSharedDomain", Level.FINE);
-		
+
 		return monoResp;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.cloudfoundry.promregator.cfaccessor.CFAccessor#retrieveProcesses(java.lang.String, java.lang.String, java.lang.String)
 	 */
@@ -217,9 +219,9 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	public Mono<ListProcessesResponse> retrieveProcesses(String orgId, String spaceId, String appId) {
 		ListProcessesRequest request = ListProcessesRequest.builder().organizationId(orgId).spaceId(spaceId).applicationId(appId).build();
 		Mono<ListProcessesResponse> monoResp = this.cloudFoundryClient.processes().list(request);
-		
+
 		monoResp = monoResp.log(log.getName()+".retrieveProcesses", Level.FINE);
-		
+
 		return monoResp;
 	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
@@ -16,6 +16,7 @@ import org.cloudfoundry.client.v2.shareddomains.SharedDomainEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v3.processes.ListProcessesResponse;
 import org.cloudfoundry.client.v3.processes.ProcessResource;
+import org.cloudfoundry.promregator.PromregatorApplication;
 import org.cloudfoundry.promregator.cfaccessor.CFAccessor;
 import org.cloudfoundry.promregator.config.Target;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
@@ -30,13 +31,13 @@ import reactor.core.publisher.Mono;
 @Component
 public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 	private static final Logger log = Logger.getLogger(ReactiveAppInstanceScanner.class);
-	
+
 	private PassiveExpiringMap<String, Mono<String>> orgMap;
 	private PassiveExpiringMap<String, Mono<String>> spaceMap;
 	private PassiveExpiringMap<String, Mono<String>> applicationMap;
 	private PassiveExpiringMap<String, Mono<String>> hostnameMap;
 	private PassiveExpiringMap<String, Mono<String>> domainMap;
-	
+
 	@Value("${cf.cache.timeout.application:300}")
 	private int timeoutCacheApplicationLevel;
 
@@ -48,20 +49,20 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 
 	@Autowired
 	private CFAccessor cfAccessor;
-	
+
 	@Autowired
 	private InternalMetrics internalMetrics;
 
 	private static class InternalInstance implements Cloneable {
-		
+
 		public Target target;
-		
+
 		public Mono<String> orgId;
 		public Mono<String> spaceId;
 		public Mono<String> applicationId;
-		
+
 		public String instanceId;
-		
+
 		public String accessUrl;
 
 		@Override
@@ -71,19 +72,19 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 			other.orgId = this.orgId;
 			other.spaceId = this.spaceId;
 			other.applicationId = this.applicationId;
-			
+
 			other.instanceId = this.instanceId;
-			
+
 			other.accessUrl = accessUrl;
 			return other;
 		}
-		
+
 		public Instance toInstance() {
 			return new Instance(this.target, this.instanceId, this.accessUrl);
 		}
-		
+
 	}
-	
+
 	@PostConstruct
 	public void setupMaps() {
 		this.orgMap = new PassiveExpiringMap<>(this.timeoutCacheOrgLevel, TimeUnit.SECONDS);
@@ -95,75 +96,97 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 		 * - apps can start and stop, we need to see this, too
 		 * - instances can be added to apps
 		 * - Blue/green deployment may alter both of them
-		 * 
+		 *
 		 * In short: both are very volatile and we need to query them often
 		 */
 		this.applicationMap = new PassiveExpiringMap<>(this.timeoutCacheApplicationLevel, TimeUnit.SECONDS);
 		this.hostnameMap = new PassiveExpiringMap<>(this.timeoutCacheApplicationLevel, TimeUnit.SECONDS);
 		this.domainMap = new PassiveExpiringMap<>(this.timeoutCacheApplicationLevel, TimeUnit.SECONDS);
 	}
-	
-	
+
+
 	public List<Instance> determineInstancesFromTargets(List<Target> targets) {
 		LinkedList<Instance> result = new LinkedList<>();
-		
-		Flux<Target> initialFlux = Flux.fromIterable(targets);
-		
-		Flux<InternalInstance> initialInstancesOnlyApplication = initialFlux.map( target -> {
+
+		Flux<Target> initialFlux = this.expandTargets(Flux.fromIterable(targets));
+
+		Flux<InternalInstance> initialInstancesOnlyApplication = initialFlux.map(target -> {
 			InternalInstance i = new InternalInstance();
-			
+
 			i.target = target;
-			
+
 			i.orgId = getOrgId(i.target.getOrgName());
 			i.spaceId = getSpaceId(i.orgId, i.target.getSpaceName());
 			i.applicationId = getApplicationId(i.orgId, i.spaceId, i.target.getApplicationName());
-			
+
 			return i;
 		});
-		
+
 		Flux<InternalInstance> instancesOfApplications = this.getInstances(initialInstancesOnlyApplication);
-		
+
 		instancesOfApplications.flatMap(instance -> {
 			Mono<String> applUrlMono = this.getApplicationUrl(instance.applicationId, instance.target.getProtocol());
-			
+
 			Mono<String> accessUrlMono = Mono.zip(applUrlMono, Mono.just(instance.target.getPath()))
-			.map(tuple -> {
-				String applUrl = tuple.getT1();
-				if (!applUrl.endsWith("/")) {
-					applUrl += '/';
-				}
-				
-				String path = tuple.getT2();
-				while (path.startsWith("/"))
-					path = path.substring(1);
-				
-				return applUrl + path;
-			});
-			
+					.map(tuple -> {
+						String applUrl = tuple.getT1();
+						if (!applUrl.endsWith("/")) {
+							applUrl += '/';
+						}
+
+						String path = tuple.getT2();
+						while (path.startsWith("/"))
+							path = path.substring(1);
+
+						return applUrl + path;
+					});
+
 			Mono<InternalInstance> newInstance = Mono.zip(Mono.just(instance), accessUrlMono)
-			.map(tuple -> {
-				InternalInstance i = tuple.getT1();
-				i.accessUrl = tuple.getT2();
-				
-				return i;
-			});
-			
+					.map(tuple -> {
+						InternalInstance i = tuple.getT1();
+						i.accessUrl = tuple.getT2();
+
+						return i;
+					});
+
 			return newInstance;
 		}).map(internalInstance -> internalInstance.toInstance()).toIterable().forEach(result::add);
-		
+
 		return result;
+	}
+
+	private Flux<Target> expandTargets(Flux<Target> inputTargets) {
+
+		return inputTargets.flatMap(target -> {
+			if (!target.getApplicationName().equalsIgnoreCase(PromregatorApplication.SPACE_ALL_APPLICATIONS)) {
+				return Mono.just(target);
+			}
+			Mono<String> orgId = getOrgId(target.getOrgName());
+			Mono<String> spaceId = getSpaceId(orgId, target.getSpaceName());
+			Flux<ApplicationResource> apps = allApplicationByOrgAndSpace(orgId, spaceId);
+
+			return apps.map(a -> {
+				Target t = new Target();
+				t.setOrgName(target.getOrgName());
+				t.setSpaceName(target.getSpaceName());
+				t.setPath(target.getPath());
+				t.setProtocol(target.getProtocol());
+				t.setApplicationName(a.getEntity().getName());
+				return t;
+			});
+		});
 	}
 
 	private static class ReactiveTimer {
 		private Timer t;
 		private final InternalMetrics im;
 		private final String requestType;
-		
+
 		public ReactiveTimer(final InternalMetrics im, final String requestType) {
 			this.im = im;
 			this.requestType = requestType;
 		}
-		
+
 		public void start() {
 			this.t = this.im.startTimerCFFetch(this.requestType);
 		}
@@ -174,7 +197,7 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 			}
 		}
 	}
-	
+
 	private Mono<String> getOrgId(String orgNameString) {
 		Mono<String> cached = this.orgMap.get(orgNameString);
 		if (cached != null) {
@@ -182,9 +205,9 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 			return cached;
 		}
 		this.internalMetrics.countMiss("appinstancescanner.org");
-		
+
 		ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, "org");
-		
+
 		cached = Mono.just(orgNameString)
 		// start the timer
 		.zipWith(Mono.just(reactiveTimer)).map(tuple -> {
@@ -198,12 +221,12 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 			if (resources == null) {
 				return Mono.empty();
 			}
-			
+
 			if (resources.isEmpty()) {
 				log.warn(String.format("Received empty result on requesting org %s", orgNameString));
 				return Mono.empty();
 			}
-			
+
 			OrganizationResource organizationResource = resources.get(0);
 			return Mono.just(organizationResource.getMetadata().getId());
 		})
@@ -213,25 +236,25 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 			return tuple.getT1();
 		})
 		.cache();
-		
+
 		this.orgMap.put(orgNameString, cached);
 		return cached;
 	}
 
 	private Mono<String> getSpaceId(Mono<String> orgIdMono, String spaceNameString) {
 		String key = String.format("%d|%s", orgIdMono.hashCode(), spaceNameString);
-		
+
 		synchronized(key.intern()) {
 			Mono<String> cached = this.spaceMap.get(key);
 			if (cached != null) {
 				this.internalMetrics.countHit("appinstancescanner.space");
 				return cached;
 			}
-			
+
 			this.internalMetrics.countMiss("appinstancescanner.space");
-			
+
 			ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, "space");
-			
+
 			cached = Mono.zip(orgIdMono, Mono.just(spaceNameString))
 			// start the timer
 			.zipWith(Mono.just(reactiveTimer)).map(tuple -> {
@@ -245,12 +268,12 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				if (resources == null) {
 					return Mono.empty();
 				}
-				
+
 				if (resources.isEmpty()) {
 					log.warn(String.format("Received empty result on requesting space %s", spaceNameString));
 					return Mono.empty();
 				}
-				
+
 				SpaceResource spaceResource = resources.get(0);
 				return Mono.just(spaceResource.getMetadata().getId());
 			})
@@ -259,7 +282,7 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				tuple.getT2().stop();
 				return tuple.getT1();
 			}).cache();
-			
+
 			this.spaceMap.put(key, cached);
 			return cached;
 		}
@@ -274,11 +297,11 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				this.internalMetrics.countHit("appinstancescanner.app");
 				return cached;
 			}
-			
+
 			this.internalMetrics.countMiss("appinstancescanner.app");
-			
+
 			ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, "app");
-			
+
 			cached = Mono.zip(orgIdMono, spaceIdMono, Mono.just(applicationNameString))
 			// start the timer
 			.zipWith(Mono.just(reactiveTimer)).map(tuple -> {
@@ -292,12 +315,12 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				if (resources == null) {
 					return Mono.empty();
 				}
-				
+
 				if (resources.isEmpty()) {
 					log.warn(String.format("Received empty result on requesting application %s", applicationNameString));
 					return Mono.empty();
 				}
-				
+
 				ApplicationResource applicationResource = resources.get(0);
 				return Mono.just(applicationResource.getMetadata().getId());
 			})
@@ -306,12 +329,33 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				tuple.getT2().stop();
 				return tuple.getT1();
 			}).cache();
-			
+
 			this.applicationMap.put(key, cached);
 			return cached;
 		}
 	}
-	
+
+	private Flux<ApplicationResource> allApplicationByOrgAndSpace(Mono<String> orgIdMono, Mono<String> spaceIdMono) {
+
+		return Flux.zip(orgIdMono, spaceIdMono, Mono.just(PromregatorApplication.SPACE_ALL_APPLICATIONS))
+				.flatMap(triple ->
+						this.cfAccessor.retrieveApplicationId(triple.getT1(), triple.getT2(), triple.getT3())
+				).flatMap(response -> {
+					List<ApplicationResource> resources = response.getResources();
+					if (resources == null) {
+						return Flux.empty();
+					}
+
+					if (resources.isEmpty()) {
+						log.warn(String.format("Received empty result on requesting application %s",
+								PromregatorApplication.SPACE_ALL_APPLICATIONS));
+						return Flux.empty();
+					}
+
+					return Flux.fromIterable(resources);
+				}).filter(r -> r.getEntity().getState().equalsIgnoreCase("STARTED"));
+	}
+
 	private Mono<String> getApplicationUrl(Mono<String> applicationIdMono, String protocol) {
 		String key = String.format("%d", applicationIdMono.hashCode());
 
@@ -321,11 +365,11 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				this.internalMetrics.countHit("appinstancescanner.route");
 				return cached;
 			}
-			
+
 			this.internalMetrics.countMiss("appinstancescanner.route");
-	
+
 			ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, "route");
-			
+
 			Mono<RouteEntity> routeMono = applicationIdMono
 			// start the timer
 			.zipWith(Mono.just(reactiveTimer)).map(tuple -> {
@@ -338,37 +382,37 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				List<RouteMappingResource> resourceList = mappingResponse.getResources();
 				if (resourceList.isEmpty())
 					return Mono.empty();
-				
+
 				String routeId = resourceList.get(0).getEntity().getRouteId();
 				if (routeId == null)
 					return Mono.empty();
-				
+
 				return this.cfAccessor.retrieveRoute(routeId);
 			}).flatMap(GetRouteResponse -> {
 				RouteEntity route = GetRouteResponse.getEntity();
 				if (route == null)
 					return Mono.empty();
-				
+
 				// WARNING! route.getApplicationsUrl() is the URL back to the application
 				// and not the URL which points to the endpoint of the cell!
 				return Mono.just(route);
 			});
-			
+
 			Mono<String> domainMono = routeMono.map(route -> route.getDomainId())
 			.flatMap(domainId -> {
 				return this.getDomain(domainId);
 			});
-			
+
 			Mono<String> applicationUrlMono = Mono.zip(domainMono, routeMono)
 			.map(tuple -> {
 				String domain = tuple.getT1();
 				RouteEntity route = tuple.getT2();
-				
+
 				String url = String.format("%s://%s.%s", protocol, route.getHost(), domain);
 				if (route.getPath() != null) {
 					url += "/"+route.getPath();
 				}
-				
+
 				return url;
 			})
 			// stop the timer
@@ -376,27 +420,27 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				tuple.getT2().stop();
 				return tuple.getT1();
 			}).cache();
-			
+
 			this.hostnameMap.put(key, applicationUrlMono);
-			
+
 			return applicationUrlMono;
 		}
 	}
 
 	private Mono<String> getDomain(String domainIdString) {
 		String key = domainIdString;
-		
+
 		synchronized (key.intern()) {
 			Mono<String> cached = this.domainMap.get(key);
 			if (cached != null) {
 				this.internalMetrics.countHit("appinstancescanner.domain");
 				return cached;
 			}
-	
+
 			this.internalMetrics.countMiss("appinstancescanner.domain");
-	
+
 			ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, "domain");
-	
+
 			cached = Mono.just(domainIdString)
 			// start the timer
 			.zipWith(Mono.just(reactiveTimer)).map(tuple -> {
@@ -407,7 +451,7 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				return this.cfAccessor.retrieveSharedDomain(domainId);
 			}).map(response -> {
 				SharedDomainEntity sharedDomain = response.getEntity();
-				
+
 				return sharedDomain.getName();
 			})
 			// stop the timer
@@ -416,16 +460,16 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				return tuple.getT1();
 			})
 			.cache();
-			
+
 			this.domainMap.put(key, cached);
 			return cached;
 		}
 	}
-	
+
 	private Flux<InternalInstance> getInstances(Flux<InternalInstance> instancesFlux) {
 		Flux<InternalInstance> allInstances = instancesFlux.flatMap(instance -> {
 			ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, "instances");
-			
+
 			Mono<ListProcessesResponse> processesResponse = Mono.zip(instance.orgId, instance.spaceId, instance.applicationId)
 			// start the timer
 			.zipWith(Mono.just(reactiveTimer)).map(tuple -> {
@@ -436,7 +480,7 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				String orgId = tuple.getT1();
 				String spaceId = tuple.getT2();
 				String appId = tuple.getT3();
-				
+
 				return this.cfAccessor.retrieveProcesses(orgId, spaceId, appId);
 			})
 			// stop the timer
@@ -444,19 +488,19 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				tuple.getT2().stop();
 				return tuple.getT1();
 			});
-			
+
 			Flux<InternalInstance> fluxInstances = Mono.zip(Mono.just(instance), processesResponse, instance.applicationId)
 			.flatMapMany(tuple -> {
 				InternalInstance inst = tuple.getT1();
 				ListProcessesResponse response = tuple.getT2();
 				String appId = tuple.getT3();
-				
+
 				List<ProcessResource> resourcesList = response.getResources();
 				if (resourcesList.isEmpty())
 					return Mono.empty();
-				
+
 				int instances = resourcesList.get(0).getInstances();
-				
+
 				List<InternalInstance> resultInstances = new LinkedList<>();
 				for (int i = 0; i<instances; i++) {
 					InternalInstance clone = null;
@@ -469,14 +513,14 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 					clone.instanceId = String.format("%s:%d", appId, i);
 					resultInstances.add(clone);
 				}
-				
+
 				return Flux.fromIterable(resultInstances);
 			});
-			
+
 			return fluxInstances;
 		});
-		
+
 		return allInstances;
 	}
-	
+
 }


### PR DESCRIPTION
Resolves #35
Pragmatic extension to allow dynamic targets detection.  

It relies on a name convention to signal `promregator` when to "expand" a single target definition (with applicationName set to `SPACE_ALL_APPLICATIONS`) into multiple targets definitions - one for every  app in that org/space. 

For example the following target configuration:
```
  targets:
    - orgName: scdf-ci
      spaceName: space-christian
      path: '/actuator/prometheus' # Spring Boot micrometer actuator entry point
      applicationName: 'SPACE_ALL_APPLICATIONS'
```

Will dynamically expand the targets definitions to all applications running in the scdf-ci/space-crhistian space. 

In this PR I've extended the [ReactiveCFAccessorImpl#retrieveApplicationId](https://github.com/promregator/promregator/compare/master...tzolov:gh-35-dynamic-target-list?expand=1#diff-cd96d2c1b0fda9ca65f7a8920bd54f90R162) to drop the name filtering in case of SPACE_ALL_APPLICATIONS name, and the [ReactiveAppInstanceScanner#determineInstanceFromTargets](https://github.com/promregator/promregator/compare/master...tzolov:gh-35-dynamic-target-list?expand=1#diff-eac88078a44f3aaf65fdd4858abe390bR108) to call the [expandTargets](https://github.com/promregator/promregator/compare/master...tzolov:gh-35-dynamic-target-list?expand=1#diff-eac88078a44f3aaf65fdd4858abe390bR158) to add additional targets when the name is SPACE_ALL_APPLICATIONS
