### PR TITLE
Sonar Fixes for squid:S2293 and removed unused variables

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/cache/AutoRefreshingCacheMap.java
+++ b/src/main/java/org/cloudfoundry/promregator/cache/AutoRefreshingCacheMap.java
@@ -66,11 +66,11 @@ public class AutoRefreshingCacheMap<K, V> extends AbstractMapDecorator<K, V> {
 		
 	}
 	
-	private Map<K, EntryProperties> entryPropertiesMap = Collections.synchronizedMap(new HashMap<K, EntryProperties>());
+	private Map<K, EntryProperties> entryPropertiesMap = Collections.synchronizedMap(new HashMap<>());
 	private String name;
 	
 	public AutoRefreshingCacheMap(String cacheMapName, InternalMetrics internalMetrics, Duration expiryDuration, Duration refreshInterval, Function<K, V> loaderFunction) {
-		super(Collections.synchronizedMap(new HashMap<K, V>()));
+		super(Collections.synchronizedMap(new HashMap<>()));
 		this.refreshInterval = refreshInterval;
 		this.internalMetrics = internalMetrics;
 		this.expiryDuration = expiryDuration;

--- a/src/main/java/org/cloudfoundry/promregator/endpoint/DiscoveryEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/DiscoveryEndpoint.java
@@ -121,7 +121,7 @@ public class DiscoveryEndpoint {
 		
 		List<Instance> instances = this.cfDiscoverer.discover(null, null);
 		if (instances == null) {
-			return new ResponseEntity<DiscoveryResponse[]>(HttpStatus.SERVICE_UNAVAILABLE);
+			return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
 		}
 		
 		String localHostname = this.myHostname != null ? this.myHostname : request.getLocalName();
@@ -148,6 +148,6 @@ public class DiscoveryEndpoint {
 		
 		log.info(String.format("Returning discovery document with %d targets", result.size()));
 		
-		return new ResponseEntity<DiscoveryResponse[]>(result.toArray(new DiscoveryResponse[0]), HttpStatus.OK);
+		return new ResponseEntity<>(result.toArray(new DiscoveryResponse[0]), HttpStatus.OK);
 	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/endpoint/SingleTargetMetricsEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/SingleTargetMetricsEndpoint.java
@@ -60,7 +60,7 @@ public class SingleTargetMetricsEndpoint extends AbstractMetricsEndpoint {
 			return new ResponseEntity<>(e.toString(), HttpStatus.NOT_FOUND);
 		}
 		
-		return new ResponseEntity<String>(response, HttpStatus.OK);
+		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/endpoint/SingleTargetMetricsEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/SingleTargetMetricsEndpoint.java
@@ -108,7 +108,7 @@ public class SingleTargetMetricsEndpoint extends AbstractMetricsEndpoint {
 				.labelNames(ownTelemetryLabels)
 				.register(requestRegistry);
 		
-		List<String> labelValues = enricher.getEnrichedLabelValues(new ArrayList<String>(0));
+		List<String> labelValues = enricher.getEnrichedLabelValues(new ArrayList<>(0));
 		scrape_duration.labels(labelValues.toArray(new String[0])).set(duration.toMillis() / 1000.0);
 	}
 

--- a/src/main/java/org/cloudfoundry/promregator/fetcher/MetricsFetcherSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/fetcher/MetricsFetcherSimulator.java
@@ -48,13 +48,13 @@ public class MetricsFetcherSimulator implements MetricsFetcher {
 			try {
 				result.close();
 			} catch (IOException e) {
-				log.warn(String.format("Unable to close result ByteArrayOutputStream having read the simulation data"));
+				log.warn("Unable to close result ByteArrayOutputStream having read the simulation data");
 			}
 			
 			try {
 				is.close();
 			} catch (IOException e) {
-				log.warn(String.format("Unable to close the input stream while reading the simulation data"));
+				log.warn("Unable to close the input stream while reading the simulation data");
 			}
 		}
 		

--- a/src/main/java/org/cloudfoundry/promregator/fetcher/TextFormat004Parser.java
+++ b/src/main/java/org/cloudfoundry/promregator/fetcher/TextFormat004Parser.java
@@ -153,8 +153,8 @@ public class TextFormat004Parser {
 			log.info(String.format("Definition of metric %s without type information (assuming untyped)", metricName));
 		}
 
-		List<String> labelNames = labels == null ? new LinkedList<String>() : labels.getNames();
-		List<String> labelValues = labels == null ? new LinkedList<String>() : labels.getValues();
+		List<String> labelNames = labels == null ? new LinkedList<>() : labels.getNames();
+		List<String> labelValues = labels == null ? new LinkedList<>() : labels.getValues();
 		
 		Sample sample = new Sample(metricName, labelNames, labelValues, value);
 
@@ -165,7 +165,7 @@ public class TextFormat004Parser {
 				mfsStored.samples.add(sample);
 			} else {
 				// there is no such MFS entry yet; we have to create one
-				List<Sample> samples = new LinkedList<Sample>();
+				List<Sample> samples = new LinkedList<>();
 				samples.add(sample);
 
 				String docString = this.mapHelps.get(metricName);
@@ -265,8 +265,8 @@ public class TextFormat004Parser {
 	}
 	
 	private static class Labels {
-		private List<String> names = new LinkedList<String>();
-		private List<String> values = new LinkedList<String>();
+		private List<String> names = new LinkedList<>();
+		private List<String> values = new LinkedList<>();
 		
 		public Labels() {
 			super();

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/AbstractMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/AbstractMetricFamilySamplesEnricher.java
@@ -20,12 +20,12 @@ public abstract class AbstractMetricFamilySamplesEnricher {
 			return null;
 		}
 		
-		HashMap<String, Collector.MetricFamilySamples> newMap = new HashMap<String, Collector.MetricFamilySamples>();
+		HashMap<String, Collector.MetricFamilySamples> newMap = new HashMap<>();
 		
 		for (Entry<String, MetricFamilySamples> entry : emfs.entrySet()) {
 			MetricFamilySamples mfs = entry.getValue();
 			
-			List<Collector.MetricFamilySamples.Sample> newSamples = new LinkedList<Collector.MetricFamilySamples.Sample>();
+			List<Collector.MetricFamilySamples.Sample> newSamples = new LinkedList<>();
 			for (Collector.MetricFamilySamples.Sample sample : mfs.samples) {
 				Collector.MetricFamilySamples.Sample newSample = new Collector.MetricFamilySamples.Sample(
 						sample.name,

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/CFAllLabelsMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/CFAllLabelsMetricFamilySamplesEnricher.java
@@ -42,7 +42,7 @@ public class CFAllLabelsMetricFamilySamplesEnricher extends AbstractMetricFamily
 	
 	@Override
 	protected List<String> getEnrichedLabelNames(List<String> original) {
-		LinkedList<String> clone = new LinkedList<String>(original);
+		LinkedList<String> clone = new LinkedList<>(original);
 		
 		for (int i = 0;i< labelNames.length; i++) {
 			clone.add(labelNames[i]);
@@ -53,7 +53,7 @@ public class CFAllLabelsMetricFamilySamplesEnricher extends AbstractMetricFamily
 	
 	@Override
 	public List<String> getEnrichedLabelValues(List<String> original) {
-		LinkedList<String> clone = new LinkedList<String>(original);
+		LinkedList<String> clone = new LinkedList<>(original);
 		
 		clone.add(this.orgName);
 		clone.add(this.spaceName);

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/GenericMetricFamilySamplesPrefixRewriter.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/GenericMetricFamilySamplesPrefixRewriter.java
@@ -34,12 +34,12 @@ public class GenericMetricFamilySamplesPrefixRewriter {
 			return null;
 		}
 		
-		HashMap<String, Collector.MetricFamilySamples> newMap = new HashMap<String, Collector.MetricFamilySamples>();
+		HashMap<String, Collector.MetricFamilySamples> newMap = new HashMap<>();
 		
 		for (Entry<String, MetricFamilySamples> entry : emfs.entrySet()) {
 			MetricFamilySamples mfs = entry.getValue();
 			
-			List<Collector.MetricFamilySamples.Sample> newSamples = new LinkedList<Collector.MetricFamilySamples.Sample>();
+			List<Collector.MetricFamilySamples.Sample> newSamples = new LinkedList<>();
 			for (Collector.MetricFamilySamples.Sample sample : mfs.samples) {
 				Collector.MetricFamilySamples.Sample newSample = new Collector.MetricFamilySamples.Sample(
 						this.ensureWithPrefix(sample.name),

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/NullMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/NullMetricFamilySamplesEnricher.java
@@ -18,14 +18,14 @@ public class NullMetricFamilySamplesEnricher extends AbstractMetricFamilySamples
 	
 	@Override
 	protected List<String> getEnrichedLabelNames(List<String> original) {
-		LinkedList<String> clone = new LinkedList<String>(original);
+		LinkedList<String> clone = new LinkedList<>(original);
 
 		return clone;
 	}
 	
 	@Override
 	public List<String> getEnrichedLabelValues(List<String> original) {
-		LinkedList<String> clone = new LinkedList<String>(original);
+		LinkedList<String> clone = new LinkedList<>(original);
 		
 		return clone;
 	}

--- a/src/main/java/org/cloudfoundry/promregator/scanner/CachingTargetResolver.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/CachingTargetResolver.java
@@ -39,9 +39,9 @@ public class CachingTargetResolver implements TargetResolver {
 
 	@Override
 	public List<ResolvedTarget> resolveTargets(List<Target> configTargets) {
-		LinkedList<Target> toBeLoaded = new LinkedList<Target>();
+		LinkedList<Target> toBeLoaded = new LinkedList<>();
 		
-		LinkedList<ResolvedTarget> result = new LinkedList<ResolvedTarget>();
+		LinkedList<ResolvedTarget> result = new LinkedList<>();
 		
 		for (Target configTarget : configTargets) {
 			List<ResolvedTarget> cached = this.targetResolutionCache.get(configTarget);

--- a/src/test/java/org/cloudfoundry/promregator/PromregatorApplicationSimulatorTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/PromregatorApplicationSimulatorTest.java
@@ -47,9 +47,7 @@ public class PromregatorApplicationSimulatorTest {
 	public void testSingleInstance() {
 		@Null
 		List<Instance> actual = this.cfDiscoverer.discover(appId -> appId.equals(CFAccessorSimulator.APP_UUID_PREFIX+"100"), 
-				instance -> {
-					return (CFAccessorSimulator.APP_UUID_PREFIX+"100:1").equals(instance.getInstanceId());
-				});
+				instance -> (CFAccessorSimulator.APP_UUID_PREFIX+"100:1").equals(instance.getInstanceId()));
 		Assert.assertEquals(1, actual.size());
 	}
 

--- a/src/test/java/org/cloudfoundry/promregator/endpoint/LabelEnrichmentMockedMetricsEndpointSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/endpoint/LabelEnrichmentMockedMetricsEndpointSpringApplication.java
@@ -126,7 +126,7 @@ public class LabelEnrichmentMockedMetricsEndpointSpringApplication {
 	@Bean
 	public AuthenticationEnricher authenticationEnricher() {
 		return new NullEnricher();
-	};
+	}
 
 	@Bean
 	public UUID promregatorInstanceIdentifier() {

--- a/src/test/java/org/cloudfoundry/promregator/endpoint/MockedAppInstanceScannerEndpointSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/endpoint/MockedAppInstanceScannerEndpointSpringApplication.java
@@ -143,6 +143,6 @@ public class MockedAppInstanceScannerEndpointSpringApplication {
 	@Bean
 	public AuthenticationEnricher authenticationEnricher() {
 		return new NullEnricher();
-	};
+	}
 
 }

--- a/src/test/java/org/cloudfoundry/promregator/endpoint/MockedMetricsEndpointSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/endpoint/MockedMetricsEndpointSpringApplication.java
@@ -131,7 +131,7 @@ public class MockedMetricsEndpointSpringApplication {
 	@Bean
 	public AuthenticationEnricher authenticationEnricher() {
 		return new NullEnricher();
-	};
+	}
 
 	@Bean
 	public UUID promregatorInstanceIdentifier() {

--- a/src/test/java/org/cloudfoundry/promregator/endpoint/MockedMetricsFetcher.java
+++ b/src/test/java/org/cloudfoundry/promregator/endpoint/MockedMetricsFetcher.java
@@ -25,10 +25,10 @@ public class MockedMetricsFetcher implements MetricsFetcher {
 		String metricName = "metric_"+this.instance.getTarget().getApplicationName();
 		
 		
-		LinkedList<String> labelNames = new LinkedList<String>();
+		LinkedList<String> labelNames = new LinkedList<>();
 		labelNames.add("instanceId");
 		
-		LinkedList<String> labelValues = new LinkedList<String>();
+		LinkedList<String> labelValues = new LinkedList<>();
 		labelValues.add(this.instance.getInstanceId());
 		
 		Sample s = new Sample(metricName, labelNames, labelValues, 1.0);

--- a/src/test/java/org/cloudfoundry/promregator/mockServer/DefaultMetricsEndpointHttpHandler.java
+++ b/src/test/java/org/cloudfoundry/promregator/mockServer/DefaultMetricsEndpointHttpHandler.java
@@ -3,8 +3,6 @@ package org.cloudfoundry.promregator.mockServer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.Assert;
 
@@ -21,9 +19,7 @@ public class DefaultMetricsEndpointHttpHandler implements HttpHandler {
 	
 	@Override
 	public void handle(HttpExchange he) throws IOException {
-		Map<String, Object> parameters = new HashMap<String, Object>();
 		URI requestedUri = he.getRequestURI();
-		String query = requestedUri.getRawQuery();
 		this.headers = he.getRequestHeaders();
 		
 		Assert.assertEquals("/metrics", requestedUri.getPath());

--- a/src/test/java/org/cloudfoundry/promregator/mockServer/DefaultOAuthHttpHandler.java
+++ b/src/test/java/org/cloudfoundry/promregator/mockServer/DefaultOAuthHttpHandler.java
@@ -27,8 +27,7 @@ public class DefaultOAuthHttpHandler implements HttpHandler {
 	public void handle(HttpExchange he) throws IOException {
 		log.debug("Request was received at handler");
 		this.counterCalled++;
-		
-		Map<String, Object> parameters = new HashMap<String, Object>();
+
 		URI requestedUri = he.getRequestURI();
 
 		Assert.assertEquals("/oauth/token", requestedUri.getPath());

--- a/src/test/java/org/cloudfoundry/promregator/rewrite/GenericMetricFamilySamplesPrefixRewriterTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/rewrite/GenericMetricFamilySamplesPrefixRewriterTest.java
@@ -40,7 +40,7 @@ public class GenericMetricFamilySamplesPrefixRewriterTest {
 		Assert.assertEquals("prefix_dummyname", mfsResult.name);
 		
 		Assert.assertEquals(1, mfsResult.samples.size());
-		Sample sampleResult = mfsResult.samples.get(0);;
+		Sample sampleResult = mfsResult.samples.get(0);
 		Assert.assertEquals("prefix_dummyname", sampleResult.name);
 	}
 	
@@ -64,7 +64,7 @@ public class GenericMetricFamilySamplesPrefixRewriterTest {
 		Assert.assertEquals("prefix_dummyname", mfsResult.name);
 		
 		Assert.assertEquals(1, mfsResult.samples.size());
-		Sample sampleResult = mfsResult.samples.get(0);;
+		Sample sampleResult = mfsResult.samples.get(0);
 		Assert.assertEquals("prefix_dummyname", sampleResult.name);
 	}
 


### PR DESCRIPTION
It would seem that Master is failing with these 3 failures

Failures: 
  TextFormat004ParserTest.testIssue104:839 expected:<1> but was:<3>
  TextFormat004ParserTest.testVariant1:811 Values should be different. Actual: UNTYPED
  MergableMetricFamilySamplesTest.testIssue104:113 expected:<50> but was:<55>

I fail with the same 3 so from what I can tell I have not broken anything :)
