### PR TITLE
Fixed squid:S1155 and removed some throws that are not needed

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -52,11 +52,17 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	
 	@Value("${cf.skipSslValidation:false}")
 	private boolean skipSSLValidation;
-	
+
+	/**
+	 * @deprecated This option is no longer in use. Use cf.proxy.host and/or promregator.scraping.proxy.host instead.
+	 */
 	@Value("${cf.proxyHost:#{null}}") 
 	@Deprecated
 	private String proxyHostDeprecated;
-	
+
+	/**
+	 * @deprecated This option is no longer in use. Use cf.proxy.port and/or promregator.scraping.proxy.port instead.
+	 */
 	@Value("${cf.proxyPort:0}")
 	@Deprecated
 	private int proxyPortDeprecated;

--- a/src/main/java/org/cloudfoundry/promregator/endpoint/AbstractMetricsEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/AbstractMetricsEndpoint.java
@@ -70,10 +70,16 @@ public abstract class AbstractMetricsEndpoint {
 	@Autowired
 	private AuthenticatorController authenticatorController;
 
+	/**
+	 * @deprecated This option is no longer in use. Use cf.proxy.host and/or promregator.scraping.proxy.host instead.
+	 */
 	@Value("${cf.proxyHost:@null}")
 	@Deprecated
 	private String proxyHostDeprecated;
-	
+
+	/**
+	 * @deprecated This option is no longer in use. Use cf.proxy.port and/or promregator.scraping.proxy.port instead.
+	 */
 	@Value("${cf.proxyPort:0}")
 	@Deprecated
 	private int proxyPortDeprecated;
@@ -87,7 +93,7 @@ public abstract class AbstractMetricsEndpoint {
 	/**
 	 * The maximal processing time permitted for Scraping (in milliseconds).
 	 * The value is deprecated as it originates from the deprecated configuration option <pre>promregator.endpoint.maxProcessingTime</pre>.
-	 * Use maxProcessingTime instead.
+	 * @deprecated Use maxProcessingTime instead.
 	 */
 	@Value("${promregator.endpoint.maxProcessingTime:#{null}}")
 	@Deprecated

--- a/src/main/java/org/cloudfoundry/promregator/fetcher/TextFormat004Parser.java
+++ b/src/main/java/org/cloudfoundry/promregator/fetcher/TextFormat004Parser.java
@@ -130,9 +130,7 @@ public class TextFormat004Parser {
 			}
 			end = mValue.end();
 		}
-		
-		rest = rest.substring(end);
-		
+
 		/*
 		 * currently not supported in java simpleclient!
 		 */
@@ -346,7 +344,7 @@ public class TextFormat004Parser {
 		return -1;
 	}
 
-	private double parseGoDouble(String goDouble) throws NumberFormatException {
+	private double parseGoDouble(String goDouble) {
 		double value = 0.0;
 		if (goDouble.startsWith("Nan")) {
 			value = Double.NaN;

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/MFSUtils.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/MFSUtils.java
@@ -6,6 +6,9 @@ import java.util.HashMap;
 import io.prometheus.client.Collector.MetricFamilySamples;
 
 public class MFSUtils {
+
+	private MFSUtils() {}
+
 	public static HashMap<String, MetricFamilySamples> convertToEMFSToHashMap(Enumeration<MetricFamilySamples> emfs) {
 		HashMap<String, MetricFamilySamples> map = new HashMap<>();
 		while (emfs.hasMoreElements()) {

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
@@ -313,12 +313,12 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 	}
 
 	private String determineApplicationRoute(final List<String> urls, final List<Pattern> patterns) {
-		if (urls == null || urls.size() == 0) {
+		if (urls == null || urls.isEmpty()) {
 			log.debug("No URLs provided to determine ApplicationURL with");
 			return null;
 		}
 
-		if (patterns == null || patterns.size() == 0) {
+		if (patterns == null || patterns.isEmpty()) {
 			log.debug("No Preferred Route URL (Regex) provided; taking first Application Route in the list provided");
 			return urls.get(0);
 		}

--- a/src/main/java/org/cloudfoundry/promregator/websecurity/SecurityConfig.java
+++ b/src/main/java/org/cloudfoundry/promregator/websecurity/SecurityConfig.java
@@ -123,8 +123,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		sec.httpBasic();
 	}
 
-	private WebSecurity determineWebSecurityForEndpoint(WebSecurity secInitial, String endpoint,
-			InboundAuthorizationMode iam) throws Exception {
+	private WebSecurity determineWebSecurityForEndpoint(WebSecurity secInitial, String endpoint, InboundAuthorizationMode iam) {
 
 		WebSecurity sec = secInitial;
 		if (iam == InboundAuthorizationMode.NONE) {

--- a/src/test/java/org/cloudfoundry/promregator/JUnitTestUtils.java
+++ b/src/test/java/org/cloudfoundry/promregator/JUnitTestUtils.java
@@ -4,6 +4,8 @@ import io.prometheus.client.CollectorRegistry;
 
 public class JUnitTestUtils {
 
+	private JUnitTestUtils() {}
+
 	public static void cleanUpAll() {
 		cleanupRegistry();
 	}

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcherTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcherTest.java
@@ -56,7 +56,7 @@ public class ReactiveCFPaginatedRequestFetcherTest {
 		Assert.assertEquals(1, subjectResponse.getTotalPages().intValue());
 		Assert.assertEquals(0, subjectResponse.getTotalResults().intValue());
 		Assert.assertNotNull(subjectResponse.getResources());
-        Assert.assertTrue (subjectResponse.getResources().isEmpty());
+		Assert.assertTrue (subjectResponse.getResources().isEmpty());
 	}
 	
 	@Test

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcherTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcherTest.java
@@ -56,7 +56,7 @@ public class ReactiveCFPaginatedRequestFetcherTest {
 		Assert.assertTrue (1 == subjectResponse.getTotalPages());
 		Assert.assertTrue (0 == subjectResponse.getTotalResults());
 		Assert.assertNotNull (subjectResponse.getResources());
-		Assert.assertTrue (0 == subjectResponse.getResources().size());
+		Assert.assertTrue (subjectResponse.getResources().isEmpty());
 	}
 	
 	@Test

--- a/src/test/java/org/cloudfoundry/promregator/discovery/CFMultiDiscovererTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/discovery/CFMultiDiscovererTest.java
@@ -103,7 +103,7 @@ public class CFMultiDiscovererTest {
 		Assert.assertFalse(this.cfDiscoverer.isInstanceRegistered(i2));
 		
 		for (int i = 0;i<10;i++) {
-			if (this.removerTriggerForInstances.size() == 0) {
+			if (this.removerTriggerForInstances.isEmpty()) {
 				Thread.sleep(400);
 				continue;
 			}

--- a/src/test/java/org/cloudfoundry/promregator/mockServer/DefaultOAuthHttpHandler.java
+++ b/src/test/java/org/cloudfoundry/promregator/mockServer/DefaultOAuthHttpHandler.java
@@ -6,8 +6,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.junit.Assert;


### PR DESCRIPTION
Fixed squid:S1155
Removed some throws that are not needed
Fixed @deprecated javadocs
Removed some unneeded imports (that I forgot about in previous pulls)
Added private constructors to static utility classes
Removed a variable that was being set but never used

