### PR TITLE
Correct metrics_path back to original

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/endpoint/DiscoveryEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/DiscoveryEndpoint.java
@@ -91,7 +91,7 @@ public class DiscoveryEndpoint {
 			return __meta_promregator_target_instanceId;
 		}
 		
-		public String get__metrics_path() {
+		public String get__metrics_path__() {
 			return this.__meta_promregator_target_path;
 		}
 	}


### PR DESCRIPTION
Prometheus discovery was broken by a previous cleanup. This restores it to the previous behavior


