### PR TITLE
Change internal logger to slf4j since we are using log4j-over-slf4j already

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/PromregatorApplication.java
+++ b/src/main/java/org/cloudfoundry/promregator/PromregatorApplication.java
@@ -8,7 +8,6 @@ import java.util.concurrent.Executors;
 
 import javax.annotation.PostConstruct;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.cfaccessor.AccessorCacheType;
 import org.cloudfoundry.promregator.cfaccessor.CFAccessor;
 import org.cloudfoundry.promregator.cfaccessor.CFAccessorCache;
@@ -30,6 +29,8 @@ import org.cloudfoundry.promregator.springconfig.BasicAuthenticationSpringConfig
 import org.cloudfoundry.promregator.springconfig.ErrorSpringConfiguration;
 import org.cloudfoundry.promregator.springconfig.JMSSpringConfiguration;
 import org.cloudfoundry.promregator.websecurity.SecurityConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -52,7 +53,7 @@ import reactor.core.publisher.Hooks;
 @Import({ BasicAuthenticationSpringConfiguration.class, SecurityConfig.class, ErrorSpringConfiguration.class, JMSSpringConfiguration.class, AuthenticatorSpringConfiguration.class })
 @EnableAsync
 public class PromregatorApplication {
-	private static final Logger log = Logger.getLogger(PromregatorApplication.class);
+	private static final Logger log = LoggerFactory.getLogger(PromregatorApplication.class);
 	
 	@Value("${promregator.simulation.enabled:false}")
 	private boolean simulationMode;

--- a/src/main/java/org/cloudfoundry/promregator/auth/AuthenticationEnricherFactory.java
+++ b/src/main/java/org/cloudfoundry/promregator/auth/AuthenticationEnricherFactory.java
@@ -1,10 +1,11 @@
 package org.cloudfoundry.promregator.auth;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.config.AuthenticatorConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AuthenticationEnricherFactory {
-	private static final Logger log = Logger.getLogger(AuthenticationEnricherFactory.class);
+	private static final Logger log = LoggerFactory.getLogger(AuthenticationEnricherFactory.class);
 	
 	private AuthenticationEnricherFactory() {
 		// left blank intentionally

--- a/src/main/java/org/cloudfoundry/promregator/auth/OAuth2XSUAAEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/auth/OAuth2XSUAAEnricher.java
@@ -23,15 +23,16 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.config.OAuth2XSUAAAuthenticationConfiguration;
 
 import com.google.gson.Gson;
 import com.google.json.JsonSanitizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OAuth2XSUAAEnricher implements AuthenticationEnricher {
 	
-	private static final Logger log = Logger.getLogger(OAuth2XSUAAEnricher.class);
+	private static final Logger log = LoggerFactory.getLogger(OAuth2XSUAAEnricher.class);
 	
 	static final CloseableHttpClient httpclient = HttpClients.createDefault();
 

--- a/src/main/java/org/cloudfoundry/promregator/cache/AutoRefreshingCacheMap.java
+++ b/src/main/java/org/cloudfoundry/promregator/cache/AutoRefreshingCacheMap.java
@@ -10,9 +10,10 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.apache.commons.collections4.map.AbstractMapDecorator;
-import org.apache.log4j.Logger;
-import org.apache.log4j.MDC;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 public class AutoRefreshingCacheMap<K, V> extends AbstractMapDecorator<K, V> {
 	private Duration refreshInterval;
@@ -216,7 +217,7 @@ public class AutoRefreshingCacheMap<K, V> extends AbstractMapDecorator<K, V> {
 	}
 
 	private static class RefresherThread<K, V> extends Thread {
-		private static final Logger log = Logger.getLogger(RefresherThread.class);
+		private static final Logger log = LoggerFactory.getLogger(RefresherThread.class);
 		
 		private AutoRefreshingCacheMap<K, V> map;
 		

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
@@ -7,13 +7,14 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.cloudfoundry.client.v2.applications.ListApplicationsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -26,7 +27,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 public class CFAccessorCacheCaffeine implements CFAccessorCache {
-	private static final Logger log = Logger.getLogger(CFAccessorCacheCaffeine.class);
+	private static final Logger log = LoggerFactory.getLogger(CFAccessorCacheCaffeine.class);
 
 	private AsyncLoadingCache<String, ListOrganizationsResponse> orgCache;
 	private AsyncLoadingCache<Void, ListOrganizationsResponse> allOrgIdCache;

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
@@ -5,20 +5,21 @@ import java.util.concurrent.TimeoutException;
 
 import javax.annotation.PostConstruct;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.client.v2.applications.ListApplicationsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.promregator.cache.AutoRefreshingCacheMap;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
 import reactor.core.publisher.Mono;
 
 public class CFAccessorCacheClassic implements CFAccessorCache {
-	private static final Logger log = Logger.getLogger(CFAccessorCacheClassic.class);
+	private static final Logger log = LoggerFactory.getLogger(CFAccessorCacheClassic.class);
 
 	private AutoRefreshingCacheMap<String, Mono<ListOrganizationsResponse>> orgCache;
 	private AutoRefreshingCacheMap<CacheKeySpace, Mono<ListSpacesResponse>> spaceCache;

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
@@ -6,7 +6,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.client.v2.Metadata;
 import org.cloudfoundry.client.v2.applications.ApplicationEntity;
 import org.cloudfoundry.client.v2.applications.ApplicationResource;
@@ -20,6 +19,8 @@ import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 public class CFAccessorSimulator implements CFAccessor {
@@ -29,7 +30,7 @@ public class CFAccessorSimulator implements CFAccessor {
 	public static final String APP_HOST_PREFIX = "hostapp";
 	public static final String SHARED_DOMAIN = "shared.domain.example.org";
 	
-	private static final Logger log = Logger.getLogger(CFAccessorSimulator.class);
+	private static final Logger log = LoggerFactory.getLogger(CFAccessorSimulator.class);
 	
 	public static final String CREATED_AT_TIMESTAMP = "2014-11-24T19:32:49+00:00";
 	public static final String UPDATED_AT_TIMESTAMP = "2014-11-24T19:32:49+00:00";

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -8,7 +8,6 @@ import java.util.regex.Pattern;
 import javax.annotation.PostConstruct;
 
 import org.apache.http.conn.util.InetAddressUtils;
-import org.apache.log4j.Logger;
 import org.cloudfoundry.client.v2.applications.ApplicationResource;
 import org.cloudfoundry.client.v2.applications.ListApplicationsRequest;
 import org.cloudfoundry.client.v2.applications.ListApplicationsResponse;
@@ -31,6 +30,8 @@ import org.cloudfoundry.reactor.ProxyConfiguration;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
 import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -39,7 +40,7 @@ import reactor.core.publisher.Mono;
 
 public class ReactiveCFAccessorImpl implements CFAccessor {
 
-	private static final Logger log = Logger.getLogger(ReactiveCFAccessorImpl.class);
+	private static final Logger log = LoggerFactory.getLogger(ReactiveCFAccessorImpl.class);
 	
 	@Value("${cf.api_host}")
 	private String apiHost;

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcher.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcher.java
@@ -7,18 +7,19 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.logging.Level;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.client.v2.OrderDirection;
 import org.cloudfoundry.client.v2.PaginatedRequest;
 import org.cloudfoundry.client.v2.PaginatedResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 class ReactiveCFPaginatedRequestFetcher {
-	private static final Logger log = Logger.getLogger(ReactiveCFPaginatedRequestFetcher.class);
+	private static final Logger log = LoggerFactory.getLogger(ReactiveCFPaginatedRequestFetcher.class);
 
 	private static final int MAX_SUPPORTED_RESULTS_PER_PAGE = 100;
 	private static final int RESULTS_PER_PAGE = MAX_SUPPORTED_RESULTS_PER_PAGE;

--- a/src/main/java/org/cloudfoundry/promregator/config/Target.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/Target.java
@@ -1,16 +1,18 @@
 package org.cloudfoundry.promregator.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class Target {
-	private static final Logger log = Logger.getLogger(Target.class);
+	private static final Logger log = LoggerFactory.getLogger(Target.class);
 
 	private String orgName;
 

--- a/src/main/java/org/cloudfoundry/promregator/config/validations/PreferredRouteRegexMustBeCompilable.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/validations/PreferredRouteRegexMustBeCompilable.java
@@ -4,13 +4,14 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.config.PromregatorConfiguration;
 import org.cloudfoundry.promregator.config.Target;
 import org.springframework.util.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PreferredRouteRegexMustBeCompilable implements ConfigurationValidation {
-	private static final Logger log = Logger.getLogger(PreferredRouteRegexMustBeCompilable.class);
+	private static final Logger log = LoggerFactory.getLogger(PreferredRouteRegexMustBeCompilable.class);
 	
 	@Override
 	public String validate(PromregatorConfiguration promregatorConfiguration) {

--- a/src/main/java/org/cloudfoundry/promregator/config/validations/TargetsHaveConsistentAuthenticatorId.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/validations/TargetsHaveConsistentAuthenticatorId.java
@@ -2,10 +2,11 @@ package org.cloudfoundry.promregator.config.validations;
 
 import java.util.HashSet;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.config.PromregatorConfiguration;
 import org.cloudfoundry.promregator.config.Target;
 import org.cloudfoundry.promregator.config.TargetAuthenticatorConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * All targets must have an authenticatorId (if specified), which is specified
@@ -13,7 +14,7 @@ import org.cloudfoundry.promregator.config.TargetAuthenticatorConfiguration;
  *
  */
 public class TargetsHaveConsistentAuthenticatorId implements ConfigurationValidation {
-	private static final Logger log = Logger.getLogger(TargetsHaveConsistentAuthenticatorId.class);
+	private static final Logger log = LoggerFactory.getLogger(TargetsHaveConsistentAuthenticatorId.class);
 
 	@Override
 	public String validate(PromregatorConfiguration promregatorConfiguration) {
@@ -34,7 +35,7 @@ public class TargetsHaveConsistentAuthenticatorId implements ConfigurationValida
 			}
 
 			if (!authenticatorIds.contains(target.getAuthenticatorId())) {
-				log.fatal(String.format(
+				log.error(String.format(
 						"Configuration error: Target %s refers to authenticator with identifier %s, but the latter does not exist",
 						target.toString(), target.getAuthenticatorId()));
 				broken = true;

--- a/src/main/java/org/cloudfoundry/promregator/discovery/CFMultiDiscoverer.java
+++ b/src/main/java/org/cloudfoundry/promregator/discovery/CFMultiDiscoverer.java
@@ -13,20 +13,21 @@ import java.util.function.Predicate;
 
 import javax.validation.constraints.Null;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.config.PromregatorConfiguration;
 import org.cloudfoundry.promregator.messagebus.MessageBusDestination;
 import org.cloudfoundry.promregator.scanner.AppInstanceScanner;
 import org.cloudfoundry.promregator.scanner.Instance;
 import org.cloudfoundry.promregator.scanner.ResolvedTarget;
 import org.cloudfoundry.promregator.scanner.TargetResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 
 public class CFMultiDiscoverer implements CFDiscoverer {
-	private static final Logger log = Logger.getLogger(CFMultiDiscoverer.class);
+	private static final Logger log = LoggerFactory.getLogger(CFMultiDiscoverer.class);
 	
 	@Autowired
 	private TargetResolver targetResolver;

--- a/src/main/java/org/cloudfoundry/promregator/endpoint/AbstractMetricsEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/AbstractMetricsEndpoint.java
@@ -18,7 +18,6 @@ import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.Null;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.auth.AuthenticationEnricher;
 import org.cloudfoundry.promregator.auth.AuthenticatorController;
 import org.cloudfoundry.promregator.discovery.CFMultiDiscoverer;
@@ -34,6 +33,8 @@ import org.cloudfoundry.promregator.rewrite.MergableMetricFamilySamples;
 import org.cloudfoundry.promregator.rewrite.NullMetricFamilySamplesEnricher;
 import org.cloudfoundry.promregator.scanner.Instance;
 import org.cloudfoundry.promregator.scanner.ResolvedTarget;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -53,7 +54,7 @@ import io.prometheus.client.Gauge.Builder;
 // being ignored by the Framework. Workaround: Annotate the implementing class instead
 public abstract class AbstractMetricsEndpoint {
 	
-	private static final Logger log = Logger.getLogger(AbstractMetricsEndpoint.class);
+	private static final Logger log = LoggerFactory.getLogger(AbstractMetricsEndpoint.class);
 	
 	@Value("${promregator.simulation.enabled:false}")
 	private boolean simulationMode;

--- a/src/main/java/org/cloudfoundry/promregator/endpoint/DiscoveryEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/DiscoveryEndpoint.java
@@ -5,9 +5,10 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.discovery.CFMultiDiscoverer;
 import org.cloudfoundry.promregator.scanner.Instance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
@@ -26,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 @Scope(value=WebApplicationContext.SCOPE_REQUEST)
 public class DiscoveryEndpoint {
 
-	private static final Logger log = Logger.getLogger(DiscoveryEndpoint.class);
+	private static final Logger log = LoggerFactory.getLogger(DiscoveryEndpoint.class);
 	
 	@Autowired
 	private CFMultiDiscoverer cfDiscoverer;

--- a/src/main/java/org/cloudfoundry/promregator/endpoint/MetricsEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/MetricsEndpoint.java
@@ -3,9 +3,10 @@ package org.cloudfoundry.promregator.endpoint;
 import java.time.Duration;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.fetcher.MetricsFetcher;
 import org.cloudfoundry.promregator.scanner.Instance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,7 @@ import io.prometheus.client.exporter.common.TextFormat;
 @Scope(value=WebApplicationContext.SCOPE_REQUEST) // see also https://github.com/promregator/promregator/issues/51
 @RequestMapping(EndpointConstants.ENDPOINT_PATH_SINGLE_ENDPOINT_SCRAPING)
 public class MetricsEndpoint extends AbstractMetricsEndpoint {
-	private static final Logger log = Logger.getLogger(MetricsEndpoint.class);
+	private static final Logger log = LoggerFactory.getLogger(MetricsEndpoint.class);
 
 	@GetMapping(produces=TextFormat.CONTENT_TYPE_004)
 	public ResponseEntity<String> getMetrics() {

--- a/src/main/java/org/cloudfoundry/promregator/endpoint/SingleTargetMetricsEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/SingleTargetMetricsEndpoint.java
@@ -4,12 +4,13 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.rewrite.AbstractMetricFamilySamplesEnricher;
 import org.cloudfoundry.promregator.rewrite.CFAllLabelsMetricFamilySamplesEnricher;
 import org.cloudfoundry.promregator.rewrite.NullMetricFamilySamplesEnricher;
 import org.cloudfoundry.promregator.scanner.Instance;
 import org.cloudfoundry.promregator.scanner.ResolvedTarget;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +29,7 @@ import io.prometheus.client.exporter.common.TextFormat;
 @RequestMapping(EndpointConstants.ENDPOINT_PATH_SINGLE_TARGET_SCRAPING+"/{applicationId}/{instanceNumber}")
 public class SingleTargetMetricsEndpoint extends AbstractMetricsEndpoint {
 	
-	private static final Logger log = Logger.getLogger(SingleTargetMetricsEndpoint.class);
+	private static final Logger log = LoggerFactory.getLogger(SingleTargetMetricsEndpoint.class);
 
 	private Instance instance;
 	

--- a/src/main/java/org/cloudfoundry/promregator/fetcher/CFMetricsFetcher.java
+++ b/src/main/java/org/cloudfoundry/promregator/fetcher/CFMetricsFetcher.java
@@ -16,7 +16,6 @@ import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.auth.AuthenticationEnricher;
 import org.cloudfoundry.promregator.endpoint.EndpointConstants;
 import org.cloudfoundry.promregator.rewrite.AbstractMetricFamilySamplesEnricher;
@@ -25,6 +24,8 @@ import org.cloudfoundry.promregator.textformat004.Parser;
 import io.prometheus.client.Collector.MetricFamilySamples;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A MetricsFetcher is a class which retrieves Prometheus metrics at an endpoint URL, which is run
@@ -39,7 +40,7 @@ public class CFMetricsFetcher implements MetricsFetcher {
 	
 	private static final String HTTP_HEADER_CF_APP_INSTANCE = "X-CF-APP-INSTANCE";
 
-	private static final Logger log = Logger.getLogger(CFMetricsFetcher.class);
+	private static final Logger log = LoggerFactory.getLogger(CFMetricsFetcher.class);
 	
 	private String endpointUrl;
 	private String instanceId;

--- a/src/main/java/org/cloudfoundry/promregator/fetcher/MetricsFetcherSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/fetcher/MetricsFetcherSimulator.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.Random;
 
 import org.apache.http.client.methods.HttpGet;
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.auth.AuthenticationEnricher;
 import org.cloudfoundry.promregator.rewrite.AbstractMetricFamilySamplesEnricher;
 import org.cloudfoundry.promregator.textformat004.Parser;
@@ -16,9 +15,11 @@ import org.cloudfoundry.promregator.textformat004.Parser;
 import io.prometheus.client.Collector.MetricFamilySamples;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MetricsFetcherSimulator implements MetricsFetcher {
-	private static final Logger log = Logger.getLogger(MetricsFetcherSimulator.class);
+	private static final Logger log = LoggerFactory.getLogger(MetricsFetcherSimulator.class);
 	
 	private String accessURL;
 	private AuthenticationEnricher ae;

--- a/src/main/java/org/cloudfoundry/promregator/lifecycle/InstanceLifecycleHandler.java
+++ b/src/main/java/org/cloudfoundry/promregator/lifecycle/InstanceLifecycleHandler.java
@@ -3,17 +3,18 @@ package org.cloudfoundry.promregator.lifecycle;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.promregator.fetcher.MetricsFetcherMetrics;
 import org.cloudfoundry.promregator.messagebus.MessageBusDestination;
 import org.cloudfoundry.promregator.rewrite.AbstractMetricFamilySamplesEnricher;
 import org.cloudfoundry.promregator.rewrite.CFAllLabelsMetricFamilySamplesEnricher;
 import org.cloudfoundry.promregator.scanner.Instance;
 import org.cloudfoundry.promregator.springconfig.JMSSpringConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.jms.annotation.JmsListener;
 
 public class InstanceLifecycleHandler {
-	private static final Logger log = Logger.getLogger(InstanceLifecycleHandler.class);
+	private static final Logger log = LoggerFactory.getLogger(InstanceLifecycleHandler.class);
 	
 	@JmsListener(destination=MessageBusDestination.DISCOVERER_INSTANCE_REMOVED, containerFactory=JMSSpringConfiguration.BEAN_NAME_JMS_LISTENER_CONTAINER_FACTORY)
 	public void receiver(Instance instance) {

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/MergableMetricFamilySamples.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/MergableMetricFamilySamples.java
@@ -10,15 +10,15 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import org.apache.log4j.Logger;
-
 import io.prometheus.client.Collector.MetricFamilySamples;
 import io.prometheus.client.Collector.Type;
 import io.prometheus.client.exporter.common.TextFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MergableMetricFamilySamples {
 	
-	private static final Logger log = Logger.getLogger(MergableMetricFamilySamples.class);
+	private static final Logger log = LoggerFactory.getLogger(MergableMetricFamilySamples.class);
 	
 	private HashMap<String, MetricFamilySamples> map = new HashMap<>();
 	

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
@@ -11,12 +11,13 @@ import java.util.regex.Pattern;
 
 import javax.validation.constraints.Null;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.client.v2.organizations.OrganizationResource;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.promregator.cfaccessor.CFAccessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -26,7 +27,7 @@ import reactor.core.publisher.Mono;
 
 public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 	
-	private static final Logger log = Logger.getLogger(ReactiveAppInstanceScanner.class);
+	private static final Logger log = LoggerFactory.getLogger(ReactiveAppInstanceScanner.class);
 	private static final String INVALID_ORG_ID = "***invalid***";
 	private static final String INVALID_SPACE_ID = "***invalid***";
 	private static final Map<String, SpaceApplicationSummary> INVALID_SUMMARY = new HashMap<>();

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
@@ -6,7 +6,6 @@ import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.log4j.Logger;
 import org.cloudfoundry.client.v2.applications.ApplicationResource;
 import org.cloudfoundry.client.v2.applications.ListApplicationsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
@@ -15,13 +14,15 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.promregator.cfaccessor.CFAccessor;
 import org.cloudfoundry.promregator.config.Target;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class ReactiveTargetResolver implements TargetResolver {
-	private static final Logger log = Logger.getLogger(ReactiveTargetResolver.class);
+	private static final Logger log = LoggerFactory.getLogger(ReactiveTargetResolver.class);
 	
 	@Autowired
 	private CFAccessor cfAccessor;

--- a/src/main/java/org/cloudfoundry/promregator/textformat004/MetricLine.java
+++ b/src/main/java/org/cloudfoundry/promregator/textformat004/MetricLine.java
@@ -5,12 +5,12 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.log4j.Logger;
-
 import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MetricLine {
-	private static final Logger log = Logger.getLogger(MetricLine.class);
+	private static final Logger log = LoggerFactory.getLogger(MetricLine.class);
 	
 	private static final Pattern PATTERN_TOKEN_WITH_SPACE_SEPARATOR = Pattern.compile("^([a-zA-Z0-9:_\\\"]+)");
 	private static final Pattern PATTERN_SKIP_SPACES = Pattern.compile("[ \\\\t]*");

--- a/src/main/java/org/cloudfoundry/promregator/textformat004/Parser.java
+++ b/src/main/java/org/cloudfoundry/promregator/textformat004/Parser.java
@@ -7,19 +7,19 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.log4j.Logger;
-
 import io.prometheus.client.Collector;
 import io.prometheus.client.Collector.MetricFamilySamples;
 import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import io.prometheus.client.Collector.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /* Unfortunately, there is nothing provided for this by Prometheus.io :-(
  * So, we have to do this ourselves.
  * Details of the format are described at https://prometheus.io/docs/instrumenting/exposition_formats/
  */
 public class Parser {
-	private static final Logger log = Logger.getLogger(Parser.class);
+	private static final Logger log = LoggerFactory.getLogger(Parser.class);
 	
 	private String textFormat004data;
 	

--- a/src/test/java/org/cloudfoundry/promregator/cache/AutoRefreshingCacheMapTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cache/AutoRefreshingCacheMapTest.java
@@ -3,17 +3,18 @@ package org.cloudfoundry.promregator.cache;
 
 import java.time.Duration;
 
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
 public class AutoRefreshingCacheMapTest {
-	private static final Logger log = Logger.getLogger(AutoRefreshingCacheMapTest.class);
+	private static final Logger log = LoggerFactory.getLogger(AutoRefreshingCacheMapTest.class);
 
 	@Test
 	public void testPutAndGet() {

--- a/src/test/java/org/cloudfoundry/promregator/cache/CaffeineAsyncLoadingTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cache/CaffeineAsyncLoadingTest.java
@@ -5,7 +5,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.Assert;
 
@@ -15,11 +14,13 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.testing.FakeTicker;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 public class CaffeineAsyncLoadingTest {
-	private static final Logger log = Logger.getLogger(CaffeineAsyncLoadingTest.class);
+	private static final Logger log = LoggerFactory.getLogger(CaffeineAsyncLoadingTest.class);
 
 	private final class AsyncCacheLoaderTimingImplementation implements AsyncCacheLoader<String, Integer> {
 		private int executionNumber = 0;

--- a/src/test/java/org/cloudfoundry/promregator/mockServer/DefaultOAuthHttpHandler.java
+++ b/src/test/java/org/cloudfoundry/promregator/mockServer/DefaultOAuthHttpHandler.java
@@ -7,11 +7,12 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultOAuthHttpHandler implements HttpHandler {
 	private int counterCalled = 0;
@@ -19,7 +20,7 @@ public class DefaultOAuthHttpHandler implements HttpHandler {
 	private String response = "";
 
 	
-	private static final Logger log = Logger.getLogger(DefaultOAuthHttpHandler.class);
+	private static final Logger log = LoggerFactory.getLogger(DefaultOAuthHttpHandler.class);
 	
 	@Override
 	public void handle(HttpExchange he) throws IOException {


### PR DESCRIPTION
This just updates the logger to remove confusion and be more efficient. 

I didn't remove the log4j-over-slf4j dependency since I wasn't certain if some log4j loggers were in use by third party libs.