### PR TITLE
Fix for #147

### DIFF
--- a/src/test/java/org/cloudfoundry/promregator/SpringBootLoadPropertiesForTesting.java
+++ b/src/test/java/org/cloudfoundry/promregator/SpringBootLoadPropertiesForTesting.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(classes = { SpringBootLoadPropertiesForTestingSpringApplication.class })
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(initializers = { ConfigFileApplicationContextInitializer.class })
-@ActiveProfiles(profiles= {"springBootLoadPropertiesForTesting"})
+@ActiveProfiles(profiles= {"springBootLoadPropertiesForTesting", "springBootLoadPropertiesForEncryptionTesting"})
 @TestPropertySource(properties = "encrypt.key=mySecretKey")
 public class SpringBootLoadPropertiesForTesting {
 

--- a/src/test/java/org/cloudfoundry/promregator/SpringBootLoadPropertiesForTestingOtherKey.java
+++ b/src/test/java/org/cloudfoundry/promregator/SpringBootLoadPropertiesForTestingOtherKey.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(classes = { SpringBootLoadPropertiesForTestingSpringApplication.class })
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(initializers = { ConfigFileApplicationContextInitializer.class })
-@ActiveProfiles(profiles= {"springBootLoadPropertiesForTestingOtherKey"})
+@ActiveProfiles(profiles= {"springBootLoadPropertiesForTestingOtherKey", "springBootLoadPropertiesForEncryptionTesting"})
 @TestPropertySource(properties = "encrypt.key=someotherkey")
 public class SpringBootLoadPropertiesForTestingOtherKey {
 

--- a/src/test/java/org/cloudfoundry/promregator/SpringBootLoadPropertiesForTestingSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/SpringBootLoadPropertiesForTestingSpringApplication.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("springBootLoadPropertiesForTesting")
+@Profile("springBootLoadPropertiesForEncryptionTesting")
 public class SpringBootLoadPropertiesForTestingSpringApplication {
 	@Value("${dummy.value:false}")
 	private boolean dummyValue;

--- a/src/test/java/org/cloudfoundry/promregator/SpringBootLoadPropertiesForTestingSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/SpringBootLoadPropertiesForTestingSpringApplication.java
@@ -4,8 +4,10 @@ import org.junit.Assert;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("springBootLoadPropertiesForTesting")
 public class SpringBootLoadPropertiesForTestingSpringApplication {
 	@Value("${dummy.value:false}")
 	private boolean dummyValue;


### PR DESCRIPTION
## Current Situation
e268363feb9aa88717d07ba9ca7c586aa0cdeb64 broke the unit test suite. 

## Problem Statement
The removal of `@Profile("springBootLoadPropertiesForTesting")` from SpringBootLoadPropertiesForTestingSpringApplication caused it to make it active for every unit test - which caused the mess.

## Solution Approach
Checketts fixed it half with a4600ea10eb88f3414152255a63630887d992016 by reintroducing the Profile annotation again, but that still kept `SpringBootLoadPropertiesForTestingOtherKey` breaking. The better solution is to have one profile name which only activates the Spring configuration `SpringBootLoadPropertiesForTestingSpringApplication` and two seperate profiles, which enables the different spring parameters. This is the approach on this PR. 

Fixes #147