### PR TITLE
Removal of log4j-over-slf4j (no longer needed) - see also #148

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,10 +106,6 @@
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>log4j-over-slf4j</artifactId>
-		</dependency>
 
 		<!-- ch.qos.logback.contrib.jackson.JacksonJsonFormatter -->
 		<dependency>


### PR DESCRIPTION
## Current Situation
#148 has removed log4j API usage in our codebase. 

## Problem Statement
#148 did not remove the dependency of log4j-over-slf4j, because it's not certain enough for 3rd party libraries.

## Solution Approach
Remove the dependency with this PR, running it in an isolated fashion. 
A manual test may safeguard us (however, I don't expect to see any surprise there).
