### PR TITLE
Added logic to remove duplicated labels

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/endpoint/AbstractMetricsEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/AbstractMetricsEndpoint.java
@@ -342,7 +342,7 @@ public abstract class AbstractMetricsEndpoint {
 			} else {
 				mfse = new NullMetricFamilySamplesEnricher();
 			}
-			upChild = this.up.labels(mfse.getEnrichedLabelValues(new LinkedList<>()).toArray(new String[0]));
+			upChild = this.up.labels(mfse.getEnrichedLabelValues(new LinkedList<>(), new LinkedList<>()).toArray(new String[0]));
 			
 			AuthenticationEnricher ae = this.authenticatorController.getAuthenticationEnricherByTarget(instance.getTarget().getOriginalTarget());
 			
@@ -370,7 +370,7 @@ public abstract class AbstractMetricsEndpoint {
 	
 	private String[] determineOwnTelemetryLabelValues(String orgName, String spaceName, String appName, String instanceId) {
 		AbstractMetricFamilySamplesEnricher mfse = new CFAllLabelsMetricFamilySamplesEnricher(orgName, spaceName, appName, instanceId);
-		List<String> labelValues = mfse.getEnrichedLabelValues(new LinkedList<>());
+		List<String> labelValues = mfse.getEnrichedLabelValues(new LinkedList<>(), new LinkedList<>());
 		
 		return labelValues.toArray(new String[0]);
 	}

--- a/src/main/java/org/cloudfoundry/promregator/endpoint/SingleTargetMetricsEndpoint.java
+++ b/src/main/java/org/cloudfoundry/promregator/endpoint/SingleTargetMetricsEndpoint.java
@@ -108,7 +108,7 @@ public class SingleTargetMetricsEndpoint extends AbstractMetricsEndpoint {
 				.labelNames(ownTelemetryLabels)
 				.register(requestRegistry);
 		
-		List<String> labelValues = enricher.getEnrichedLabelValues(new ArrayList<>(0));
+		List<String> labelValues = enricher.getEnrichedLabelValues(new ArrayList<>(), new ArrayList<>(0));
 		scrapeDuration.labels(labelValues.toArray(new String[0])).set(duration.toMillis() / 1000.0);
 	}
 

--- a/src/main/java/org/cloudfoundry/promregator/lifecycle/InstanceLifecycleHandler.java
+++ b/src/main/java/org/cloudfoundry/promregator/lifecycle/InstanceLifecycleHandler.java
@@ -30,7 +30,7 @@ public class InstanceLifecycleHandler {
 		String appName = instance.getTarget().getApplicationName();
 		
 		AbstractMetricFamilySamplesEnricher mfse = new CFAllLabelsMetricFamilySamplesEnricher(orgName, spaceName, appName, instance.getInstanceId());
-		List<String> labelValues = mfse.getEnrichedLabelValues(new LinkedList<>());
+		List<String> labelValues = mfse.getEnrichedLabelValues( new LinkedList<>(), new LinkedList<>());
 		String[] ownTelemetryLabelValues = labelValues.toArray(new String[0]);
 		
 		MetricsFetcherMetrics mfm = new MetricsFetcherMetrics(ownTelemetryLabelValues, true);

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/AbstractMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/AbstractMetricFamilySamplesEnricher.java
@@ -48,9 +48,7 @@ public abstract class AbstractMetricFamilySamplesEnricher {
 	}
 	
 	protected abstract List<String> getEnrichedLabelNames(List<String> original);
-	
-	public abstract List<String> getEnrichedLabelValues(List<String> original);
 
-	protected abstract List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues);
+	public abstract List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues);
 
 }

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/AbstractMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/AbstractMetricFamilySamplesEnricher.java
@@ -27,11 +27,10 @@ public abstract class AbstractMetricFamilySamplesEnricher {
 			
 			List<Collector.MetricFamilySamples.Sample> newSamples = new LinkedList<>();
 			for (Collector.MetricFamilySamples.Sample sample : mfs.samples) {
-				this.removeDuplicateLabels(sample.labelNames);
 				Collector.MetricFamilySamples.Sample newSample = new Collector.MetricFamilySamples.Sample(
 						sample.name,
 						this.getEnrichedLabelNames(sample.labelNames),
-						this.getEnrichedLabelValues(sample.labelValues),
+						this.getEnrichedLabelValues(sample.labelNames, sample.labelValues),
 						sample.value);
 				newSamples.add(newSample);
 			}
@@ -52,6 +51,6 @@ public abstract class AbstractMetricFamilySamplesEnricher {
 	
 	public abstract List<String> getEnrichedLabelValues(List<String> original);
 
-	protected abstract void removeDuplicateLabels(List<String> original);
-	
+	protected abstract List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues);
+
 }

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/AbstractMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/AbstractMetricFamilySamplesEnricher.java
@@ -47,7 +47,7 @@ public abstract class AbstractMetricFamilySamplesEnricher {
 		return newMap;
 	}
 	
-	protected abstract List<String> getEnrichedLabelNames(List<String> original);
+	protected abstract List<String> getEnrichedLabelNames(List<String> originalLabelNames);
 
 	public abstract List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues);
 

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/AbstractMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/AbstractMetricFamilySamplesEnricher.java
@@ -27,6 +27,7 @@ public abstract class AbstractMetricFamilySamplesEnricher {
 			
 			List<Collector.MetricFamilySamples.Sample> newSamples = new LinkedList<>();
 			for (Collector.MetricFamilySamples.Sample sample : mfs.samples) {
+				this.removeDuplicateLabels(sample.labelNames);
 				Collector.MetricFamilySamples.Sample newSample = new Collector.MetricFamilySamples.Sample(
 						sample.name,
 						this.getEnrichedLabelNames(sample.labelNames),
@@ -51,6 +52,6 @@ public abstract class AbstractMetricFamilySamplesEnricher {
 	
 	public abstract List<String> getEnrichedLabelValues(List<String> original);
 
-
-
+	protected abstract void removeDuplicateLabels(List<String> original);
+	
 }

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/CFAllLabelsMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/CFAllLabelsMetricFamilySamplesEnricher.java
@@ -49,29 +49,64 @@ public class CFAllLabelsMetricFamilySamplesEnricher extends AbstractMetricFamily
 	protected List<String> getEnrichedLabelNames(List<String> original) {
 		List<String> clone = new LinkedList<>(original);
 		for(String label: labelNames) {
-			clone.remove(label);
-			//TODO: log that label was removed
+			if(clone.indexOf(label) < 0) {
+				clone.add(label);
+			} else {
+				//TODO: log that label already existed
+			}
 		}
-		Collections.addAll(clone, labelNames);
 		return clone;
 	}
 
 	@Override
 	public List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues) {
-		List<String> labelListClone = new LinkedList<>(originalLabelValues);
-		Set<String> originalLabelNamesSet = new HashSet<>(originalLabelNames);
+		List<String> clone = new LinkedList<>(originalLabelValues);
+		boolean orgNameExists = false;
+		boolean spaceNameExists = false;
+		boolean appNameExists = false;
+		boolean instanceIdExists = false;
+		boolean instanceNumberExists = false;
+
 		for(String label: labelNames) {
-			if(originalLabelNamesSet.contains(label)){
-				labelListClone.remove(originalLabelNames.indexOf(label));
-				//TODO: Log that value was removed
+			int index = originalLabelNames.indexOf(label);
+			if(index > -1){
+				switch (label){
+					case LABELNAME_ORGNAME:
+						clone.set(index, orgName);
+						orgNameExists = true;
+						//TODO: log that value already existed
+						break;
+					case LABELNAME_SPACENAME:
+						clone.set(index, spaceName);
+						spaceNameExists = true;
+						//TODO: log that value already existed
+						break;
+					case LABELNAME_APPNAME:
+						clone.set(index, appName);
+						appNameExists = true;
+						//TODO: log that value already existed
+						break;
+					case LABELNAME_INSTANCEID:
+						clone.set(index, instanceId);
+						instanceIdExists = true;
+						//TODO: log that value already existed
+						break;
+					case LABELNAME_INSTANCE_NUMBER:
+						clone.set(index, getInstanceFromInstanceId(instanceId));
+						instanceNumberExists = true;
+						//TODO: log that value already existed
+						break;
+				}
 			}
 		}
-		labelListClone.add(orgName);
-		labelListClone.add(spaceName);
-		labelListClone.add(appName);
-		labelListClone.add(instanceId);
-		labelListClone.add(getInstanceFromInstanceId(instanceId));
-		return labelListClone;
+
+		if(!orgNameExists) {clone.add(orgName);}
+		if(!spaceNameExists) {clone.add(spaceName);}
+		if(!appNameExists){clone.add(appName);}
+		if(!instanceIdExists){clone.add(instanceId);}
+		if(!instanceNumberExists){clone.add(getInstanceFromInstanceId(instanceId));}
+
+		return clone;
 	}
 
 	private static String getInstanceFromInstanceId(String instanceId) {

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/CFAllLabelsMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/CFAllLabelsMetricFamilySamplesEnricher.java
@@ -2,10 +2,12 @@ package org.cloudfoundry.promregator.rewrite;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A MetricFamilySamplesEnricher which enriches the labels of metrics by 
@@ -53,28 +55,23 @@ public class CFAllLabelsMetricFamilySamplesEnricher extends AbstractMetricFamily
 		Collections.addAll(clone, labelNames);
 		return clone;
 	}
-	
-	@Override
-	public List<String> getEnrichedLabelValues(List<String> original) {
-		List<String> clone = new LinkedList<>(original);
-		clone.add(orgName);
-		clone.add(spaceName);
-		clone.add(appName);
-		clone.add(instanceId);
-		clone.add(getInstanceFromInstanceId(instanceId));
-		return clone;
-	}
 
 	@Override
-	protected List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues) {
-		List<String> clone = new LinkedList<>(originalLabelValues);
+	public List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues) {
+		List<String> labelListClone = new LinkedList<>(originalLabelValues);
+		Set<String> originalLabelNamesSet = new HashSet<>(originalLabelNames);
 		for(String label: labelNames) {
-			if(originalLabelNames.contains(label)){
-				clone.remove(originalLabelNames.indexOf(label));
-				//TODO: log that value was removed
+			if(originalLabelNamesSet.contains(label)){
+				labelListClone.remove(originalLabelNames.indexOf(label));
+				//TODO: Log that value was removed
 			}
 		}
-		return getEnrichedLabelValues(clone);
+		labelListClone.add(orgName);
+		labelListClone.add(spaceName);
+		labelListClone.add(appName);
+		labelListClone.add(instanceId);
+		labelListClone.add(getInstanceFromInstanceId(instanceId));
+		return labelListClone;
 	}
 
 	private static String getInstanceFromInstanceId(String instanceId) {

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/NullMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/NullMetricFamilySamplesEnricher.java
@@ -20,9 +20,7 @@ public class NullMetricFamilySamplesEnricher extends AbstractMetricFamilySamples
 	}
 	
 	@Override
-	protected List<String> getEnrichedLabelNames(List<String> original) {
-		return new LinkedList<>(original);
-	}
+	protected List<String> getEnrichedLabelNames(List<String> originalLabelNames) { return new LinkedList<>(originalLabelNames); }
 
 	@Override
 	public List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues) { return new LinkedList<>(originalLabelValues); }

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/NullMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/NullMetricFamilySamplesEnricher.java
@@ -29,4 +29,7 @@ public class NullMetricFamilySamplesEnricher extends AbstractMetricFamilySamples
 		return new LinkedList<>(original);
 	}
 
+	@Override
+	protected void removeDuplicateLabels(List<String> original){ }
+
 }

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/NullMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/NullMetricFamilySamplesEnricher.java
@@ -23,13 +23,8 @@ public class NullMetricFamilySamplesEnricher extends AbstractMetricFamilySamples
 	protected List<String> getEnrichedLabelNames(List<String> original) {
 		return new LinkedList<>(original);
 	}
-	
-	@Override
-	public List<String> getEnrichedLabelValues(List<String> original) {
-		return new LinkedList<>(original);
-	}
 
 	@Override
-	protected List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues) { return new LinkedList<>(originalLabelValues); }
+	public List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues) { return new LinkedList<>(originalLabelValues); }
 
 }

--- a/src/main/java/org/cloudfoundry/promregator/rewrite/NullMetricFamilySamplesEnricher.java
+++ b/src/main/java/org/cloudfoundry/promregator/rewrite/NullMetricFamilySamplesEnricher.java
@@ -30,6 +30,6 @@ public class NullMetricFamilySamplesEnricher extends AbstractMetricFamilySamples
 	}
 
 	@Override
-	protected void removeDuplicateLabels(List<String> original){ }
+	protected List<String> getEnrichedLabelValues(List<String> originalLabelNames, List<String> originalLabelValues) { return new LinkedList<>(originalLabelValues); }
 
 }

--- a/src/test/java/org/cloudfoundry/promregator/fetcher/MetricsFetcherSimulatorTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/fetcher/MetricsFetcherSimulatorTest.java
@@ -27,7 +27,7 @@ public class MetricsFetcherSimulatorTest {
 		AbstractMetricFamilySamplesEnricher mfse = new CFAllLabelsMetricFamilySamplesEnricher("testOrgName", "testSpaceName", "testapp", "testinstance1:0");
 		
 		Gauge up = Gauge.build("up_test", "help test").labelNames(CFAllLabelsMetricFamilySamplesEnricher.getEnrichingLabelNames()).create();
-		Child upChild = up.labels(mfse.getEnrichedLabelValues(new LinkedList<>()).toArray(new String[0]));
+		Child upChild = up.labels(mfse.getEnrichedLabelValues(new LinkedList<>(), new LinkedList<>()).toArray(new String[0]));
 		
 		MetricsFetcherSimulator subject = new MetricsFetcherSimulator("accessUrl", 
 				new NullEnricher(), mfse , 

--- a/src/test/java/org/cloudfoundry/promregator/fetcher/MetricsFetcherTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/fetcher/MetricsFetcherTest.java
@@ -69,7 +69,7 @@ public class MetricsFetcherTest {
 	public void testStraightForward() throws Exception {
 		String instanceId = "abcd:4";
 		NullMetricFamilySamplesEnricher dummymfse = new NullMetricFamilySamplesEnricher("dummy", "dummy", "dummy", "dummy:0");
-		List<String> labelValues = dummymfse.getEnrichedLabelValues(new LinkedList<>());
+		List<String> labelValues = dummymfse.getEnrichedLabelValues(new LinkedList<>(), new LinkedList<>());
 		String[] ownTelemetryLabelValues = labelValues.toArray(new String[0]);
 		
 		MetricsFetcherMetrics mfm = new MetricsFetcherMetrics(ownTelemetryLabelValues, false);
@@ -115,7 +115,7 @@ public class MetricsFetcherTest {
 		String instanceId = "abcd:2";
 		TestAuthenticationEnricher ae = new TestAuthenticationEnricher();
 		NullMetricFamilySamplesEnricher dummymfse = new NullMetricFamilySamplesEnricher("dummy", "dummy", "dummy", "dummy:0");
-		List<String> labelValues = dummymfse.getEnrichedLabelValues(new LinkedList<>());
+		List<String> labelValues = dummymfse.getEnrichedLabelValues(new LinkedList<>(), new LinkedList<>());
 		String[] ownTelemetryLabelValues = labelValues.toArray(new String[0]);
 		
 		MetricsFetcherMetrics mfm = new MetricsFetcherMetrics(ownTelemetryLabelValues, false);
@@ -146,7 +146,7 @@ public class MetricsFetcherTest {
 	public void testSocketReadTimeoutTriggered() throws Exception {
 		String instanceId = "abcd:7";
 		NullMetricFamilySamplesEnricher dummymfse = new NullMetricFamilySamplesEnricher("dummy", "dummy", "dummy", "dummy:0");
-		List<String> labelValues = dummymfse.getEnrichedLabelValues(new LinkedList<>());
+		List<String> labelValues = dummymfse.getEnrichedLabelValues(new LinkedList<>(), new LinkedList<>());
 		String[] ownTelemetryLabelValues = labelValues.toArray(new String[0]);
 		
 		MetricsFetcherMetrics mfm = new MetricsFetcherMetrics(ownTelemetryLabelValues, false);
@@ -173,7 +173,7 @@ public class MetricsFetcherTest {
 	public void testInvalidEndpointURL() throws Exception {
 		String instanceId = "abcd:8";
 		NullMetricFamilySamplesEnricher dummymfse = new NullMetricFamilySamplesEnricher("dummy", "dummy", "dummy", "dummy:0");
-		List<String> labelValues = dummymfse.getEnrichedLabelValues(new LinkedList<>());
+		List<String> labelValues = dummymfse.getEnrichedLabelValues(new LinkedList<>(), new LinkedList<>());
 		String[] ownTelemetryLabelValues = labelValues.toArray(new String[0]);
 		
 		MetricsFetcherMetrics mfm = new MetricsFetcherMetrics(ownTelemetryLabelValues, false);

--- a/src/test/java/org/cloudfoundry/promregator/fetcher/MetricsFetcherTestTLSPKIX.java
+++ b/src/test/java/org/cloudfoundry/promregator/fetcher/MetricsFetcherTestTLSPKIX.java
@@ -59,7 +59,7 @@ public class MetricsFetcherTestTLSPKIX {
 	public void testPKIXErrorOnSelfSignedCertificateInDefaultMode() throws Exception {
 		String instanceId = "abcd:4";
 		NullMetricFamilySamplesEnricher dummymfse = new NullMetricFamilySamplesEnricher("dummy", "dummy", "dummy", "dummy:0");
-		List<String> labelValues = dummymfse.getEnrichedLabelValues(new LinkedList<>());
+		List<String> labelValues = dummymfse.getEnrichedLabelValues(new LinkedList<>(), new LinkedList<>());
 		String[] ownTelemetryLabelValues = labelValues.toArray(new String[0]);
 		
 		MetricsFetcherMetrics mfm = new MetricsFetcherMetrics(ownTelemetryLabelValues, false);

--- a/src/test/java/org/cloudfoundry/promregator/lifecycle/InstanceLifecycleHandlerTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/lifecycle/InstanceLifecycleHandlerTest.java
@@ -46,7 +46,7 @@ public class InstanceLifecycleHandlerTest {
 		String appName = i.getTarget().getApplicationName();
 		
 		AbstractMetricFamilySamplesEnricher mfse = new CFAllLabelsMetricFamilySamplesEnricher(orgName, spaceName, appName, i.getInstanceId());
-		List<String> labelValues = mfse.getEnrichedLabelValues(new LinkedList<>());
+		List<String> labelValues = mfse.getEnrichedLabelValues(new LinkedList<>(),new LinkedList<>());
 		String[] ownTelemetryLabelValues = labelValues.toArray(new String[0]);
 		
 		MetricsFetcherMetrics mfm = new MetricsFetcherMetrics(ownTelemetryLabelValues, true);

--- a/src/test/java/org/cloudfoundry/promregator/rewrite/MetricFamilySamplesEnricherTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/rewrite/MetricFamilySamplesEnricherTest.java
@@ -105,7 +105,7 @@ public class MetricFamilySamplesEnricherTest {
 	}
 
 	@Test
-	public void testDuplicatesRemovedFromMetricLabels() {
+	public void testEnrichedLabelsRemovesLabelDuplication() {
 		AbstractMetricFamilySamplesEnricher subject = new CFAllLabelsMetricFamilySamplesEnricher("testOrgName", "testSpaceName", "testComponent", "testInstance:42");
 
 		List<Sample> samples = new LinkedList<>();
@@ -130,22 +130,22 @@ public class MetricFamilySamplesEnricherTest {
 		List<String> labelNamesList = testSample.labelNames;
 		Assert.assertEquals("There should be exactly six labels", 6,labelNamesList.size());
 		String[] labelNames = labelNamesList.toArray(new String[0]);
-		Assert.assertEquals("The first label should have been the app_name", "app_name", labelNames[0]);
-		Assert.assertEquals("The first label should have been the labelName", "labelName", labelNames[1]);
-		Assert.assertEquals("The first label should have been the testOrgName", "org_name", labelNames[2]);
-		Assert.assertEquals("The first label should have been the testSpaceName", "space_name", labelNames[3]);
-		Assert.assertEquals("The first label should have been the testComponent", "cf_instance_id", labelNames[4]);
-		Assert.assertEquals("The first label should have been the testComponent", "cf_instance_number", labelNames[5]);
+		Assert.assertEquals("The original label should have been first", "labelName", labelNames[0]);
+		Assert.assertEquals("The second label should have been the testOrgName", "org_name", labelNames[1]);
+		Assert.assertEquals("The third label should have been the testSpaceName", "space_name", labelNames[2]);
+		Assert.assertEquals("The fourth label should have been the app_name", "app_name", labelNames[3]);
+		Assert.assertEquals("The fifth label should have been the testComponent", "cf_instance_id", labelNames[4]);
+		Assert.assertEquals("The sixth label should have been the testComponent", "cf_instance_number", labelNames[5]);
 
 		List<String> labelValuesList = testSample.labelValues;
 		Assert.assertEquals("There should be exactly 6 values",6, labelValuesList.size());
 		String[] labelValues = labelValuesList.toArray(new String[0]);
-		Assert.assertEquals("The app_name should not have been empty or overridden", "original_appName", labelValues[0]);
-		Assert.assertEquals("The second value should have been labelvalue", "labelvalue", labelValues[1]);
-		Assert.assertEquals("The second value should have been testOrgName", "testOrgName", labelValues[2]);
-		Assert.assertEquals("The second value should have been testSpaceName", "testSpaceName", labelValues[3]);
-		Assert.assertEquals("The second value should have been testComponent", "testInstance:42", labelValues[4]);
-		Assert.assertEquals("The second value should have been testInstance:42", "42", labelValues[5]);
+		Assert.assertEquals("The original value should have been first", "labelvalue", labelValues[0]);
+		Assert.assertEquals("The second value should have been org name", "testOrgName", labelValues[1]);
+		Assert.assertEquals("The third value should have been space name", "testSpaceName", labelValues[2]);
+		Assert.assertEquals("The fourth value should have been the appName", "testComponent", labelValues[3]);
+		Assert.assertEquals("The fifth value should have been testComponent", "testInstance:42", labelValues[4]);
+		Assert.assertEquals("The sixth value should have been testInstance:42", "42", labelValues[5]);
 	}
 
 }


### PR DESCRIPTION

## Current Situation
Currently if a metric has a label that is also provided by the label enrichment.  The metric ends up with a duplicated label.

## Problem Statement
In newer version of prometheus this causes the prometheus process to consume a high amount of CPU, and is blocked all together by the newest version of prometheus.  See issue: https://github.com/prometheus/prometheus/issues/6655

## Solution Approach
If a metric already has a label that would be added via label enrichment, let the metrics original label take priority and not add that label via label enrichment.
