### PR TITLE
Dispose ConnectionContext if applicable upon Watchdog reset

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -201,6 +201,23 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	@Override
 	public void reset() {
 		try {
+			if (this.cloudFoundryClient != null) {
+				/*
+				 * Note: there may still be connections and threads open, which need to be closed.
+				 * https://github.com/promregator/promregator/issues/161 pointed that out.
+				 */
+				final ConnectionContext connectionContext = this.cloudFoundryClient.getConnectionContext();
+				if (connectionContext != null && connectionContext instanceof DefaultConnectionContext) {
+					/*
+					 * For the idea see also 
+					 * https://github.com/cloudfoundry/cf-java-client/issues/777 and
+					 * https://issues.jenkins-ci.org/browse/JENKINS-53136
+					 */
+					DefaultConnectionContext dcc = (DefaultConnectionContext) connectionContext;
+					dcc.dispose();
+				}
+			}
+			
 			ProxyConfiguration proxyConfiguration = this.proxyConfiguration();
 			DefaultConnectionContext connectionContext = this.connectionContext(proxyConfiguration);
 			PasswordGrantTokenProvider tokenProvider = this.tokenProvider();


### PR DESCRIPTION
## Current Situation
The CF Watchdog is able to trigger a connection reset in case a non-working connectivity is detected.  This leads to recreating the cf-java-client.

## Problem Statement
A watchdog-initiated reset of the CFAccessor may lead to thread leakage, as connections and their worker threads are not closed automatically.

## Solution Approach
Explicitly dispose the resources associated with the ConnectionContext.

closes #161 
