### PR TITLE
Suppress logging of warning message, if no target found - #164

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -657,6 +657,16 @@ For the purpose of debugging issues with asynchronous handling of operations esp
 
 Be default, this option is set to `false`.
 
+### Option "promregator.resolver.logging.empty.target" (optional)
+
+Suppresses warning messages written to Promregator's logs, which hint to an incomplete resolution of a target. 
+
+The default value of this option is `true`, i.e. logging takes place. If set to `false`, logging will be suppressed. 
+
+If you are expecting that your Promregator's configuration will specify targets, which will never be resolved to an effective targets (e.g. you have specified no orgName, no spaceName and an application name which will never exist on your entire Cloud Foundry platform), you should set this option to `false`. Otherwise the log may get flooded by useless warning messages.
+
+Note, it is best practice to *not* have such target configurations in first place: It is comparably costly for Promregator to detect these cases during runtime. Moreover, as Promregator cannot determine whether only "currently there is no such target" or "there never will be such a target", Promregator still needs to query all metadata from the Cloud Foundry platform. Hence, switching off logging may cover a warning of a valid misconfiguration and shall be used wisely.
+
 
 ### Option "promregator.workaround.dnscache.timeout" (optional)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -657,16 +657,6 @@ For the purpose of debugging issues with asynchronous handling of operations esp
 
 Be default, this option is set to `false`.
 
-### Option "promregator.resolver.logging.empty.target" (optional)
-
-Suppresses warning messages written to Promregator's logs, which hint to an incomplete resolution of a target. 
-
-The default value of this option is `true`, i.e. logging takes place. If set to `false`, logging will be suppressed. 
-
-If you are expecting that your Promregator's configuration will specify targets, which will never be resolved to an effective targets (e.g. you have specified no orgName, no spaceName and an application name which will never exist on your entire Cloud Foundry platform), you should set this option to `false`. Otherwise the log may get flooded by useless warning messages.
-
-Note, it is best practice to *not* have such target configurations in first place: It is comparably costly for Promregator to detect these cases during runtime. Moreover, as Promregator cannot determine whether only "currently there is no such target" or "there never will be such a target", Promregator still needs to query all metadata from the Cloud Foundry platform. Hence, switching off logging may cover a warning of a valid misconfiguration and shall be used wisely.
-
 
 ### Option "promregator.workaround.dnscache.timeout" (optional)
 

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
@@ -358,7 +358,7 @@ public class ReactiveTargetResolver implements TargetResolver {
 					.single()
 					.doOnError(e -> {
 						if (e instanceof NoSuchElementException) {
-							logEmptyTarget.warn(String.format("Application id could not be found for org '%s', space '%s' and application '%s'. Check your configuration; skipping it for now", it.getResolvedOrgName(), it.getResolvedSpaceName(), it.getConfigTarget().getApplicationName()));
+							logEmptyTarget.warn(String.format("Application id could not be found for org '%s', space '%s' and application '%s'. Check your configuration of targets; skipping it for now; this message may be muted by setting the log level of the emitting logger accordingly!", it.getResolvedOrgName(), it.getResolvedSpaceName(), it.getConfigTarget().getApplicationName()));
 						}
 					})
 					.onErrorResume(e -> Mono.empty())

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
@@ -17,7 +17,6 @@ import org.cloudfoundry.promregator.config.Target;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -30,9 +29,6 @@ public class ReactiveTargetResolver implements TargetResolver {
 	@Autowired
 	private CFAccessor cfAccessor;
 
-	@Value("${promregator.resolver.logging.empty.target:true}")
-	private boolean emptyResolutionIsLogged;
-	
 	private static class IntermediateTarget {
 		private Target configTarget;
 		private String resolvedOrgName;

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveTargetResolver.java
@@ -25,6 +25,7 @@ import reactor.core.scheduler.Schedulers;
 
 public class ReactiveTargetResolver implements TargetResolver {
 	private static final Logger log = LoggerFactory.getLogger(ReactiveTargetResolver.class);
+	private static final Logger logEmptyTarget = LoggerFactory.getLogger(String.format("%s.EmptyTarget", ReactiveTargetResolver.class.getName()));
 	
 	@Autowired
 	private CFAccessor cfAccessor;
@@ -356,8 +357,8 @@ public class ReactiveTargetResolver implements TargetResolver {
 					.filter(appResource -> appNameToSearchFor.equals(appResource.getEntity().getName().toLowerCase(Locale.ENGLISH)))
 					.single()
 					.doOnError(e -> {
-						if (e instanceof NoSuchElementException && this.emptyResolutionIsLogged) {
-							log.warn(String.format("Application id could not be found for org '%s', space '%s' and application '%s'. Check your configuration; skipping it for now", it.getResolvedOrgName(), it.getResolvedSpaceName(), it.getConfigTarget().getApplicationName()));
+						if (e instanceof NoSuchElementException) {
+							logEmptyTarget.warn(String.format("Application id could not be found for org '%s', space '%s' and application '%s'. Check your configuration; skipping it for now", it.getResolvedOrgName(), it.getResolvedSpaceName(), it.getConfigTarget().getApplicationName()));
 						}
 					})
 					.onErrorResume(e -> Mono.empty())


### PR DESCRIPTION
## Current Situation
There can be a large number of warning messages of type 

```
Application id could not be found for org '%s', space '%s' and application '%s'. Check your configuration; skipping it for now
```

if the target configuration includes empty-target definitions.

## Problem Statement
The log is flooded with these messages unnecessarily.

## Solution Approach
An additional configuration option `promregator.resolver.logging.empty.target` is introduced which permits switching off the warning messages.

## Post Activities
- [ ] Adding release notes

closes #164
