### PR TITLE
Don't pass 'null' for all orgs.

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
@@ -29,7 +29,7 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 	private static final Logger log = Logger.getLogger(CFAccessorCacheCaffeine.class);
 
 	private AsyncLoadingCache<String, ListOrganizationsResponse> orgCache;
-	private AsyncLoadingCache<Void, ListOrganizationsResponse> allOrgIdCache;
+	private AsyncLoadingCache<String, ListOrganizationsResponse> allOrgIdCache;
 	private AsyncLoadingCache<CacheKeySpace, ListSpacesResponse> spaceCache;
 	private AsyncLoadingCache<String, ListSpacesResponse> spaceIdInOrgCache;
 	private AsyncLoadingCache<CacheKeyAppsInSpace, ListApplicationsResponse> appsInSpaceCache;
@@ -101,10 +101,10 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 				.refreshAfterWrite(this.refreshCacheOrgLevelInSeconds, TimeUnit.SECONDS)
 				.recordStats()
 				.scheduler(caffeineScheduler)
-				.buildAsync(new AsyncCacheLoader<Void, ListOrganizationsResponse>() {
+				.buildAsync(new AsyncCacheLoader<String, ListOrganizationsResponse>() {
 
 					@Override
-					public @NonNull CompletableFuture<ListOrganizationsResponse> asyncLoad(@NonNull Void key,
+					public @NonNull CompletableFuture<ListOrganizationsResponse> asyncLoad(@NonNull String key,
 							@NonNull Executor executor) {
 						
 						Mono<ListOrganizationsResponse> mono = parent.retrieveAllOrgIds()
@@ -221,7 +221,7 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 	
 	@Override
 	public Mono<ListOrganizationsResponse> retrieveAllOrgIds() {
-		return Mono.fromFuture(this.allOrgIdCache.get(null));
+		return Mono.fromFuture(this.allOrgIdCache.get("all"));
 	}
 	
 	@Override

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineTest.java
@@ -76,6 +76,12 @@ public class CFAccessorCacheCaffeineTest {
 	}
 
 	@Test
+	public void testRetrieveAllOrgIds() {
+		subject.retrieveAllOrgIds();
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllOrgIds();
+	}
+	
+	@Test
 	public void testRetrieveSpaceSummary() {
 		Mono<GetSpaceSummaryResponse> response1 = subject.retrieveSpaceSummary("dummy");
 		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveSpaceSummary("dummy");


### PR DESCRIPTION
In #170 the user it trying to use an `orgRegex` and is seeing a null pointer.

This fixes by using a hard coded "all" instead of a hard coded `null`. This does not need to be backported in simplifiedProm since we use a different key there (the API)