### PR TITLE
Add ability for partial result for discovery

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/internalmetrics/InternalMetrics.java
+++ b/src/main/java/org/cloudfoundry/promregator/internalmetrics/InternalMetrics.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.promregator.internalmetrics;
 
 import javax.annotation.PostConstruct;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import org.springframework.beans.factory.annotation.Value;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
@@ -116,7 +117,7 @@ public class InternalMetrics {
 		this.connectionWatchdogReconnects.inc();
 	}
 	
-	public void addCaffeineCache(String cacheName, AsyncLoadingCache<?, ?> cache) {
+	public void addCaffeineCache(String cacheName, Cache<?, ?> cache) {
 		if (!this.enabled)
 			return;
 		

--- a/src/main/java/org/cloudfoundry/promregator/scanner/BackPressure.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/BackPressure.java
@@ -1,0 +1,63 @@
+package org.cloudfoundry.promregator.scanner;
+
+import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public class BackPressure {
+    private static final Logger log = LoggerFactory.getLogger(BackPressure.class);
+    private final AtomicReference<Instant> startTime = new AtomicReference<>(Instant.now());
+    private final AtomicInteger totalRequests = new AtomicInteger(0);
+    private final Integer maxRequests;
+    private final AtomicInteger requestSkipped = new AtomicInteger(0);
+
+    public BackPressure(Integer maxRequests) {
+        this.maxRequests = maxRequests;
+    }
+
+    public Duration runDuration(){
+        return Duration.between(startTime.get(), Instant.now());
+    }
+
+    public int incrementRequests() {
+        return totalRequests.incrementAndGet();
+    }
+
+    public <T> Mono<T> request(Supplier<Mono<T>> monoRequest) {
+        int totalRequest = incrementRequests();
+        if(totalRequest < maxRequests){
+            return monoRequest.get();
+        } else {
+            requestSkipped.incrementAndGet();
+            log.info("Skipping mono total: {} max: {}", totalRequest, maxRequests);
+            return Mono.empty();
+        }
+    }
+
+    public int getRequestsSkipped(){
+        return requestSkipped.get();
+    }
+
+    public void reset() {
+        totalRequests.set(0);
+        startTime.set(Instant.now());
+    }
+
+    @Override
+    public String toString() {
+        return "BackPressure{" +
+                "startTime=" + startTime +
+                ", totalRequests=" + totalRequests +
+                ", maxRequests=" + maxRequests +
+                ", requestSkipped=" + requestSkipped +
+                '}';
+    }
+}

--- a/src/main/java/org/cloudfoundry/promregator/scanner/BackPressureOps.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/BackPressureOps.java
@@ -1,0 +1,53 @@
+package org.cloudfoundry.promregator.scanner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Function;
+
+
+public class BackPressureOps<T> implements Function<Mono<List<T>>, Mono<List<T>>> {
+    private static Logger LOG = LoggerFactory.getLogger(BackPressureOps.class);
+    private final int maxRetries;
+    private final int maxRequests;
+
+    public BackPressureOps(int maxRetries, int maxRequests) {
+        this.maxRetries = maxRetries;
+        this.maxRequests = maxRequests;
+    }
+
+    @Override
+    public Mono<List<T>> apply(Mono<List<T>> flux) {
+        return flux.flatMap(results -> Mono.subscriberContext().map(ctx -> {
+            BackPressure bp = ctx.get("backpressure");
+            int skips = bp.getRequestsSkipped();
+            LOG.info("Got results: " + results.size() + " backpressue: " + skips);
+            if (skips > 0) {
+                bp.reset();
+                throw new IncompleteResultException(skips, results);
+            }
+
+            return results;
+        }))
+                .retryBackoff(maxRetries, Duration.ofSeconds(1), Duration.ofSeconds(10))
+                .onErrorResume(t -> {
+                    Throwable rootCause = t;
+                    if(t.getCause() instanceof IncompleteResultException) {
+                        rootCause = t.getCause();
+                    }
+
+                    if (rootCause instanceof IncompleteResultException) {
+                        @SuppressWarnings("unchecked") Mono<List<T>> result = Mono.just(((IncompleteResultException) rootCause).getResults());
+                        return result;
+                    } else {
+                        return Mono.error(t);
+                    }
+                })
+                .subscriberContext(Context.of("backpressure", new BackPressure(maxRequests)));
+    }
+
+}

--- a/src/main/java/org/cloudfoundry/promregator/scanner/IncompleteResultException.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/IncompleteResultException.java
@@ -1,0 +1,24 @@
+package org.cloudfoundry.promregator.scanner;
+
+import java.util.List;
+
+public class IncompleteResultException extends RuntimeException {
+    private final int failedRequests;
+    private final List results;
+
+    public IncompleteResultException(int failedRequests, List results) {
+
+        super("Failed to collect complete result. Requests not completed: "+failedRequests);
+        this.failedRequests = failedRequests;
+        this.results = results;
+    }
+
+    public int getFailedRequests() {
+        return failedRequests;
+    }
+
+
+    public List getResults() {
+        return results;
+    }
+}


### PR DESCRIPTION

## Current Situation
As noted in #170, Promregator can pound the CFCC by sending too many requests. This is an idea for how we could support that.

## Problem Statement
Since targets with regexes can fan out into many requests. 

## Solution Approach
This solution keeps track of the number of requests are being made to the CFCC so we could configure a limit on them. Optionally, we might be able to use the total time the request is taking as well, but I didn't try that.  

A big change is we would move from the AsyncCacheLoader to a manual one. This allows us to determine if a request has already been cached and decide if we want to make it or not.

This was an investigative spike to discuss the approach more than a hardened solution