### PR TITLE
NPE on non-parsable Metric Line

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/textformat004/MetricLine.java
+++ b/src/main/java/org/cloudfoundry/promregator/textformat004/MetricLine.java
@@ -27,7 +27,7 @@ public class MetricLine {
 		this.line = line;
 	}
 
-	private static class ParseException extends Exception {
+	public static class ParseException extends Exception {
 
 		private static final long serialVersionUID = 291766462453425092L;
 
@@ -41,31 +41,27 @@ public class MetricLine {
 		
 	}
 	
-	public Sample parse() {
+	public Sample parse() throws ParseException {
 		this.rest = line;
 
-		try {
-			final String metricName = this.parseMetricName();
-			this.skipSpacesIfThereAre();
-			
-			// check if the metric has an optional block of labels
-			final Labels labels = this.parseLabels();
-			
-			final double value = this.parseValue();
-			/*
-			 * The timestamp is optional.
-			 * Note that timestamps for metrics are currently not supported by the java Simpleclient!
-			 * Yet it is defined the official protocol specification. 
-			 */
-			final double timestamp = this.parseTimestamp();
-			
-			final List<String> labelNames = labels == null ? new LinkedList<>() : labels.getNames();
-			final List<String> labelValues = labels == null ? new LinkedList<>() : labels.getValues();
-			
-			return new Sample(metricName, labelNames, labelValues, value);
-		} catch (ParseException e) {
-			return null;
-		}
+		final String metricName = this.parseMetricName();
+		this.skipSpacesIfThereAre();
+		
+		// check if the metric has an optional block of labels
+		final Labels labels = this.parseLabels();
+		
+		final double value = this.parseValue();
+		/*
+		 * The timestamp is optional.
+		 * Note that timestamps for metrics are currently not supported by the java Simpleclient!
+		 * Yet it is defined the official protocol specification. 
+		 */
+		final double timestamp = this.parseTimestamp();
+		
+		final List<String> labelNames = labels == null ? new LinkedList<>() : labels.getNames();
+		final List<String> labelValues = labels == null ? new LinkedList<>() : labels.getValues();
+		
+		return new Sample(metricName, labelNames, labelValues, value);
 	}
 	
 	private String parseMetricName() throws ParseException {

--- a/src/main/java/org/cloudfoundry/promregator/textformat004/Parser.java
+++ b/src/main/java/org/cloudfoundry/promregator/textformat004/Parser.java
@@ -70,7 +70,14 @@ public class Parser {
 	
 	private void parseMetric(String line) {
 		final MetricLine ml = new MetricLine(line);
-		Sample sample = ml.parse();
+		
+		Sample sample = null;
+		try {
+			sample = ml.parse();
+		} catch (MetricLine.ParseException e) {
+			log.warn(String.format("Detected non-parsable metric line '%s'", line), e);
+			return;
+		}
 		
 		final String metricName = sample.name;
 		

--- a/src/test/java/org/cloudfoundry/promregator/textformat004/ParserTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/textformat004/ParserTest.java
@@ -11,7 +11,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.assertj.core.util.Lists;
 import org.cloudfoundry.promregator.JUnitTestUtils;
 import org.cloudfoundry.promregator.rewrite.MFSUtils;
 import org.cloudfoundry.promregator.textformat004.Parser;
@@ -882,7 +881,7 @@ public class ParserTest {
 
 		samples = new LinkedList<>();
 
-		samples.add(new Sample("another_metric", Lists.emptyList(),Lists.emptyList(), 123.1));
+		samples.add(new Sample("another_metric", Collections.emptyList(), Collections.emptyList(), 123.1));
 		expectedMFS = new Collector.MetricFamilySamples("another_metric", Type.GAUGE, "", samples);
 		expectedList.add(expectedMFS);
 		

--- a/src/test/java/org/cloudfoundry/promregator/textformat004/ParserTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/textformat004/ParserTest.java
@@ -11,6 +11,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.assertj.core.util.Lists;
 import org.cloudfoundry.promregator.JUnitTestUtils;
 import org.cloudfoundry.promregator.rewrite.MFSUtils;
 import org.cloudfoundry.promregator.textformat004.Parser;
@@ -877,6 +878,12 @@ public class ParserTest {
 		samples.add(sample);
 		
 		Collector.MetricFamilySamples expectedMFS = new Collector.MetricFamilySamples("metric_with_label", Type.GAUGE, "", samples);
+		expectedList.add(expectedMFS);
+
+		samples = new LinkedList<>();
+
+		samples.add(new Sample("another_metric", Lists.emptyList(),Lists.emptyList(), 123.1));
+		expectedMFS = new Collector.MetricFamilySamples("another_metric", Type.GAUGE, "", samples);
 		expectedList.add(expectedMFS);
 		
 		Enumeration<Collector.MetricFamilySamples> expected = Collections.enumeration(expectedList);

--- a/src/test/java/org/cloudfoundry/promregator/textformat004/ParserTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/textformat004/ParserTest.java
@@ -847,5 +847,41 @@ public class ParserTest {
 		
 		Assert.assertEquals(0.034350549,  mfs.samples.get(65).value, 0.001);
 	}
+	
+	@Test
+	// see also issue #175
+	public void testGaugeNonParsableJunk() {
+		String textToParse = "# TYPE metric_with_label gauge\n" + 
+				"metric_with_label{name=\"xyz\"} 12.47\n"
+				+ "\n"
+				+ "some_garbage abc----\n"
+				+ "\n"
+				+ "# TYPE another_metric gauge\n"
+				+ "another_metric 123.1\n";
 		
+		Parser subject = new Parser(textToParse);
+		HashMap<String, Collector.MetricFamilySamples> resultMap = subject.parse();
+		Enumeration<Collector.MetricFamilySamples> result = Collections.enumeration(resultMap.values());
+
+		// creating expected result
+		LinkedList<Collector.MetricFamilySamples> expectedList = new LinkedList<>();
+
+		List<Sample> samples = new LinkedList<>();
+		
+		List<String> labelNames = new LinkedList<>();
+		labelNames.add("name");
+		List<String> labelValues = new LinkedList<>();
+		labelValues.add("xyz");
+		
+		Sample sample = new Sample("metric_with_label", labelNames, labelValues, 12.47);
+		samples.add(sample);
+		
+		Collector.MetricFamilySamples expectedMFS = new Collector.MetricFamilySamples("metric_with_label", Type.GAUGE, "", samples);
+		expectedList.add(expectedMFS);
+		
+		Enumeration<Collector.MetricFamilySamples> expected = Collections.enumeration(expectedList);
+		
+		// compare
+		compareEMFS(expected, result);
+	}
 }


### PR DESCRIPTION
## Current Situation
In case of a non-parsable metric line, Promregator currently creates a NullPointerException. 

See also #175 .

## Solution Approach
The raised `ParseException` is propagated further and handled in the line-reading loop properly.

## Post Activities
- [x] add statement in Changelog
- [ ] provide new release candidate
- [ ] double maintenance to `simplifiedProm` necessary

closes #175 
