### PR TITLE
Add check to skip metrics if not enabled

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/internalmetrics/InternalMetrics.java
+++ b/src/main/java/org/cloudfoundry/promregator/internalmetrics/InternalMetrics.java
@@ -162,15 +162,23 @@ public class InternalMetrics {
 	}
 	
 	public void observeRateLimiterDuration(String requestType, double waitTime) {
+		if (!this.enabled)
+			return;
+
 		this.rateLimitWaitTime.labels(requestType).observe(waitTime);
-		
 	}
 	
 	public void increaseRateLimitQueueSize() {
+		if (!this.enabled)
+			return;
+
 		this.rateLimitQueueSize.incrementAndGet();
 	}
 	
 	public void decreaseRateLimitQueueSize() {
+		if (!this.enabled)
+			return;
+
 		this.rateLimitQueueSize.decrementAndGet();
 	}
 


### PR DESCRIPTION
## Current Situation
When internal metrics are disabled, calling code gets a `NullPointerException`

## Problem Statement
Since hte `InternalMetrics` aren't initialized, we need to add guards around the metric increments, etc.

## Solution Approach
Add checks similar to how we do it in other metric calls.

I'm questioning if there is a good reason to disable internal metrics. Could we just leave them on all the time for `simplifiedProm`?