### PR TITLE
WIP: Add internal domain support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.java]
+indent_style = tab
+indent_size = 1

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,4 +8,4 @@ insert_final_newline = true
 
 [*.java]
 indent_style = tab
-indent_size = 1
+indent_size = 2

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
@@ -5,6 +5,7 @@ import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 
 import reactor.core.publisher.Mono;
 
@@ -21,7 +22,9 @@ public interface CFAccessor {
 
 	Mono<ListApplicationsResponse> retrieveAllApplicationIdsInSpace(String orgId, String spaceId);
 
-	Mono<GetSpaceSummaryResponse> retrieveSpaceSummary(String spaceId);
+  Mono<GetSpaceSummaryResponse> retrieveSpaceSummary(String spaceId);
+  
+  Mono<ListDomainsResponse> retrieveDomains();
 	
 	void reset();
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
@@ -6,8 +6,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
-import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
-import org.cloudfoundry.client.v3.routes.ListRoutesResponse;
+import org.cloudfoundry.client.v3.domains.GetDomainResponse;
 
 import reactor.core.publisher.Mono;
 
@@ -26,7 +25,7 @@ public interface CFAccessor {
 
   Mono<GetSpaceSummaryResponse> retrieveSpaceSummary(String spaceId);
   
-  Mono<ListDomainsResponse> retrieveDomains();
+  Mono<GetDomainResponse> retrieveDomain(String domainId);
 
   Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId);
 	

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
@@ -22,12 +22,12 @@ public interface CFAccessor {
 	Mono<ListSpacesResponse> retrieveSpaceIdsInOrg(String orgId);
 
 	Mono<ListApplicationsResponse> retrieveAllApplicationIdsInSpace(String orgId, String spaceId);
+	
+	Mono<GetSpaceSummaryResponse> retrieveSpaceSummary(String spaceId);
+		
+	Mono<GetDomainResponse> retrieveDomain(String domainId);
 
-  Mono<GetSpaceSummaryResponse> retrieveSpaceSummary(String spaceId);
-  
-  Mono<GetDomainResponse> retrieveDomain(String domainId);
-
-  Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId);
+	Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId);
 	
 	void reset();
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
@@ -5,7 +5,9 @@ import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.routes.ListRoutesResponse;
 
 import reactor.core.publisher.Mono;
 
@@ -25,6 +27,8 @@ public interface CFAccessor {
   Mono<GetSpaceSummaryResponse> retrieveSpaceSummary(String spaceId);
   
   Mono<ListDomainsResponse> retrieveDomains();
+
+  Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId);
 	
 	void reset();
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
@@ -37,8 +37,8 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 	private AsyncLoadingCache<CacheKeySpace, ListSpacesResponse> spaceCache;
 	private AsyncLoadingCache<String, ListSpacesResponse> spaceIdInOrgCache;
 	private AsyncLoadingCache<CacheKeyAppsInSpace, ListApplicationsResponse> appsInSpaceCache;
-  private AsyncLoadingCache<String, GetSpaceSummaryResponse> spaceSummaryCache;
-  private AsyncLoadingCache<String, GetDomainResponse> domainsCache;
+	private AsyncLoadingCache<String, GetSpaceSummaryResponse> spaceSummaryCache;
+	private AsyncLoadingCache<String, GetDomainResponse> domainsCache;
 	
 	@Value("${cf.cache.timeout.org:3600}")
 	private int refreshCacheOrgLevelInSeconds;

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
@@ -14,7 +14,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
-import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.domains.GetDomainResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +38,7 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 	private AsyncLoadingCache<String, ListSpacesResponse> spaceIdInOrgCache;
 	private AsyncLoadingCache<CacheKeyAppsInSpace, ListApplicationsResponse> appsInSpaceCache;
   private AsyncLoadingCache<String, GetSpaceSummaryResponse> spaceSummaryCache;
-  private AsyncLoadingCache<String, ListDomainsResponse> domainsCache;
+  private AsyncLoadingCache<String, GetDomainResponse> domainsCache;
 	
 	@Value("${cf.cache.timeout.org:3600}")
 	private int refreshCacheOrgLevelInSeconds;
@@ -137,11 +137,11 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 		}
   }
   
-  private class DomainCacheLoader implements AsyncCacheLoader<String, ListDomainsResponse> {
+  private class DomainCacheLoader implements AsyncCacheLoader<String, GetDomainResponse> {
 		@Override
-		public @NonNull CompletableFuture<ListDomainsResponse> asyncLoad(@NonNull String key,
+		public @NonNull CompletableFuture<GetDomainResponse> asyncLoad(@NonNull String key,
 				@NonNull Executor executor) {
-			Mono<ListDomainsResponse> mono = parent.retrieveDomains()
+			Mono<GetDomainResponse> mono = parent.retrieveDomain(key)
 					.subscribeOn(Schedulers.fromExecutor(executor))
 					.cache();
 			return mono.toFuture();
@@ -258,8 +258,8 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
   }
   
   @Override
-	public Mono<ListDomainsResponse> retrieveDomains() {
-    return Mono.fromFuture(this.domainsCache.get(""));
+	public Mono<GetDomainResponse> retrieveDomain(String domainId) {
+    return Mono.fromFuture(this.domainsCache.get(domainId));
 	}
 
 

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
@@ -13,6 +13,7 @@ import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.slf4j.Logger;
@@ -287,6 +288,12 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 	@Override
 	public void reset() {
 		this.parent.reset();
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
@@ -26,7 +26,7 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	private AutoRefreshingCacheMap<String, Mono<ListOrganizationsResponse>> orgCache;
 	private AutoRefreshingCacheMap<CacheKeySpace, Mono<ListSpacesResponse>> spaceCache;
 	private AutoRefreshingCacheMap<CacheKeyAppsInSpace, Mono<ListApplicationsResponse>> appsInSpaceCache;
-	private AutoRefreshingCacheMap<String, Mono<GetSpaceSummaryResponse>> spaceSummaryCache;
+  private AutoRefreshingCacheMap<String, Mono<GetSpaceSummaryResponse>> spaceSummaryCache;
 
 	@Value("${cf.cache.timeout.org:3600}")
 	private int refreshCacheOrgLevelInSeconds;
@@ -68,7 +68,7 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 		this.orgCache = new AutoRefreshingCacheMap<>("org", this.internalMetrics, Duration.ofSeconds(this.expiryCacheOrgLevelInSeconds), Duration.ofSeconds(this.refreshCacheOrgLevelInSeconds), this::orgCacheLoader);
 		this.spaceCache = new AutoRefreshingCacheMap<>("space", this.internalMetrics, Duration.ofSeconds(this.expiryCacheSpaceLevelInSeconds), Duration.ofSeconds(refreshCacheSpaceLevelInSeconds), this::spaceCacheLoader);
 		this.appsInSpaceCache = new AutoRefreshingCacheMap<>("appsInSpace", this.internalMetrics, Duration.ofSeconds(this.expiryCacheApplicationLevelInSeconds), Duration.ofSeconds(refreshCacheApplicationLevelInSeconds), this::appsInSpaceCacheLoader);
-		this.spaceSummaryCache = new AutoRefreshingCacheMap<>("spaceSummary", this.internalMetrics, Duration.ofSeconds(this.expiryCacheApplicationLevelInSeconds), Duration.ofSeconds(refreshCacheApplicationLevelInSeconds), this::spaceSummaryCacheLoader);
+    this.spaceSummaryCache = new AutoRefreshingCacheMap<>("spaceSummary", this.internalMetrics, Duration.ofSeconds(this.expiryCacheApplicationLevelInSeconds), Duration.ofSeconds(refreshCacheApplicationLevelInSeconds), this::spaceSummaryCacheLoader);
 	}
 
 	private Mono<ListOrganizationsResponse> orgCacheLoader(String orgName) {
@@ -324,7 +324,7 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 		 */
 		
 		return mono;
-	}
+  }
 
 	@Override
 	public Mono<GetInfoResponse> getInfo() {
@@ -380,7 +380,7 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	@Override
 	public Mono<ListDomainsResponse> retrieveDomains() {		
     /*
-		 * not implemented cache here yet
+		 * not implemented cache here 
 		 */
 		return this.parent.retrieveDomains();
 	}
@@ -408,5 +408,4 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	public void reset() {
 		this.parent.reset();
 	}
-
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
@@ -10,6 +10,7 @@ import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.cloudfoundry.promregator.cache.AutoRefreshingCacheMap;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.slf4j.Logger;
@@ -373,6 +374,15 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	@Override
 	public Mono<GetSpaceSummaryResponse> retrieveSpaceSummary(String spaceId) {
 		return this.spaceSummaryCache.get(spaceId);
+  }
+  
+  
+	@Override
+	public Mono<ListDomainsResponse> retrieveDomains() {		
+    /*
+		 * not implemented cache here yet
+		 */
+		return this.parent.retrieveDomains();
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
@@ -10,6 +10,7 @@ import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.cloudfoundry.promregator.cache.AutoRefreshingCacheMap;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
@@ -407,5 +408,11 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	@Override
 	public void reset() {
 		this.parent.reset();
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
@@ -11,7 +11,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
-import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.domains.GetDomainResponse;
 import org.cloudfoundry.promregator.cache.AutoRefreshingCacheMap;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.slf4j.Logger;
@@ -379,11 +379,11 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
   
   
 	@Override
-	public Mono<ListDomainsResponse> retrieveDomains() {		
+	public Mono<GetDomainResponse> retrieveDomain(String domainId) {		
     /*
 		 * not implemented cache here 
 		 */
-		return this.parent.retrieveDomains();
+		return this.parent.retrieveDomain(domainId);
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
@@ -5,12 +5,12 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 
 import org.cloudfoundry.client.v2.Metadata;
 import org.cloudfoundry.client.v2.applications.ApplicationEntity;
 import org.cloudfoundry.client.v2.applications.ApplicationResource;
 import org.cloudfoundry.client.v2.applications.ListApplicationsResponse;
-import org.cloudfoundry.client.v2.domains.DomainEntity;
 import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.organizations.OrganizationEntity;
@@ -20,6 +20,8 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
+import org.cloudfoundry.client.v3.ToOneRelationship;
+import org.cloudfoundry.client.v3.domains.DomainRelationships;
 import org.cloudfoundry.client.v3.domains.DomainResource;
 import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.slf4j.Logger;
@@ -164,14 +166,26 @@ public class CFAccessorSimulator implements CFAccessor {
 	public Mono<ListDomainsResponse> retrieveDomains() {    
 			List<DomainResource> list = new LinkedList<>();
 			
-			for (int i = 1;i<=100;i++) {				
+			for (int i = 1;i<=10;i++) {				
 				list.add(
-          DomainResource.builder()
-          .name("cf.test.com")
+          DomainResource.builder() 
+          .id(UUID.randomUUID().toString())       
+          .isInternal(false)
+          .createdAt(CFAccessorSimulator.CREATED_AT_TIMESTAMP)
+          .relationships(
+            DomainRelationships.builder()
+            .organization(
+              ToOneRelationship.builder()
+              .data(null).build()
+            ).build()
+          )
+          .name("cf.test"+i+".com")                    
           .build());
 			}
 			
-			ListDomainsResponse resp = ListDomainsResponse.builder().addAllResources(list).build();
+      ListDomainsResponse resp = ListDomainsResponse.builder()      
+      .addAllResources(list)
+      .build();
 			
 			return Mono.just(resp).delayElement(this.getSleepRandomDuration());
 	}

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
@@ -21,6 +21,7 @@ import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v3.ToOneRelationship;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.domains.DomainRelationships;
 import org.cloudfoundry.client.v3.domains.DomainResource;
 import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
@@ -205,6 +206,12 @@ public class CFAccessorSimulator implements CFAccessor {
 	@Override
 	public void reset() {
 		// nothing to do
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
@@ -10,6 +10,7 @@ import org.cloudfoundry.client.v2.Metadata;
 import org.cloudfoundry.client.v2.applications.ApplicationEntity;
 import org.cloudfoundry.client.v2.applications.ApplicationResource;
 import org.cloudfoundry.client.v2.applications.ListApplicationsResponse;
+import org.cloudfoundry.client.v2.domains.DomainEntity;
 import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.organizations.OrganizationEntity;
@@ -19,7 +20,8 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
-
+import org.cloudfoundry.client.v3.domains.DomainResource;
+import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -156,7 +158,24 @@ public class CFAccessorSimulator implements CFAccessor {
 		
 		log.error("Invalid retrieveSpaceSummary request");
 		return null;
+  }
+  
+  @Override
+	public Mono<ListDomainsResponse> retrieveDomains() {    
+			List<DomainResource> list = new LinkedList<>();
+			
+			for (int i = 1;i<=100;i++) {				
+				list.add(
+          DomainResource.builder()
+          .name("cf.test.com")
+          .build());
+			}
+			
+			ListDomainsResponse resp = ListDomainsResponse.builder().addAllResources(list).build();
+			
+			return Mono.just(resp).delayElement(this.getSleepRandomDuration());
 	}
+
 
 	@Override
 	public Mono<GetInfoResponse> getInfo() {

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
-import java.util.UUID;
 
 import org.cloudfoundry.client.v2.Metadata;
 import org.cloudfoundry.client.v2.applications.ApplicationEntity;
@@ -20,11 +19,11 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
+import org.cloudfoundry.client.v3.Relationship;
 import org.cloudfoundry.client.v3.ToOneRelationship;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.domains.DomainRelationships;
-import org.cloudfoundry.client.v3.domains.DomainResource;
-import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.domains.GetDomainResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -34,7 +33,8 @@ public class CFAccessorSimulator implements CFAccessor {
 	public static final String SPACE_UUID = "db08be9a-2fa4-11e8-b467-0ed5f89f718b";
 	public static final String APP_UUID_PREFIX = "55820b2c-2fa5-11e8-b467-";
 	public static final String APP_HOST_PREFIX = "hostapp";
-	public static final String SHARED_DOMAIN = "shared.domain.example.org";
+  public static final String SHARED_DOMAIN = "shared.domain.example.org";
+  public static final String SHARED_DOMAIN_UUID = "be9b8696-2fa6-11e8-b467-0ed5f89f718b";  
 	
 	private static final Logger log = LoggerFactory.getLogger(CFAccessorSimulator.class);
 	
@@ -164,28 +164,22 @@ public class CFAccessorSimulator implements CFAccessor {
   }
   
   @Override
-	public Mono<ListDomainsResponse> retrieveDomains() {    
-			List<DomainResource> list = new LinkedList<>();
-			
-			for (int i = 1;i<=10;i++) {				
-				list.add(
-          DomainResource.builder() 
-          .id(UUID.randomUUID().toString())       
-          .isInternal(false)
-          .createdAt(CFAccessorSimulator.CREATED_AT_TIMESTAMP)
-          .relationships(
-            DomainRelationships.builder()
-            .organization(
-              ToOneRelationship.builder()
-              .data(null).build()
-            ).build()
-          )
-          .name("cf.test"+i+".com")                    
-          .build());
-			}
-			
-      ListDomainsResponse resp = ListDomainsResponse.builder()      
-      .addAllResources(list)
+	public Mono<GetDomainResponse> retrieveDomain(String domainId) {    
+    
+      GetDomainResponse resp = GetDomainResponse.builder()
+      .id(domainId)       
+      .isInternal(false)
+      .createdAt(CREATED_AT_TIMESTAMP)
+      .relationships(
+        DomainRelationships.builder()
+        .organization(
+          ToOneRelationship.builder()
+          .data(
+            Relationship.builder().id(ORG_UUID).build()
+          ).build()
+        ).build()
+      )
+      .name(SHARED_DOMAIN)    
       .build();
 			
 			return Mono.just(resp).delayElement(this.getSleepRandomDuration());

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -15,10 +15,8 @@ import org.cloudfoundry.client.v2.info.GetInfoRequest;
 import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesRequest;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
-import org.cloudfoundry.client.v3.domains.ListDomainsRequest;
-import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
-import org.cloudfoundry.client.v3.routes.ListRoutesRequest;
-import org.cloudfoundry.client.v3.routes.ListRoutesResponse;
+import org.cloudfoundry.client.v3.domains.GetDomainRequest;
+import org.cloudfoundry.client.v3.domains.GetDomainResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsRequest;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.organizations.OrganizationResource;
@@ -392,11 +390,13 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
   }
   
 	@Override
-	public Mono<ListDomainsResponse> retrieveDomains() {
-		ListDomainsRequest request = ListDomainsRequest.builder().build();
+	public Mono<GetDomainResponse> retrieveDomain(String domainId) {
+    // ListDomainsRequest request = ListDomainsRequest.builder().build();
+    
+    GetDomainRequest request = GetDomainRequest.builder().domainId(domainId).build();
 		
 		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.DOMAINS, "(empty)", 
-				request, r -> this.cloudFoundryClient.domainsV3().list(request), this.requestTimeoutDomains);
+				request, r -> this.cloudFoundryClient.domainsV3().get(request), this.requestTimeoutDomains);
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -13,6 +13,8 @@ import org.cloudfoundry.client.v2.applications.ListApplicationsRequest;
 import org.cloudfoundry.client.v2.applications.ListApplicationsResponse;
 import org.cloudfoundry.client.v2.info.GetInfoRequest;
 import org.cloudfoundry.client.v2.info.GetInfoResponse;
+import org.cloudfoundry.client.v3.domains.ListDomainsRequest;
+import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsRequest;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.organizations.OrganizationResource;
@@ -377,6 +379,13 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.SPACE_SUMMARY, spaceId, 
 				request, r -> this.cloudFoundryClient.spaces().getSummary(r), this.requestTimeoutAppSummary);
 
+  }
+  
+	@Override
+	public Mono<ListDomainsResponse> retrieveDomains() {
+		ListDomainsRequest request = ListDomainsRequest.builder().build();
+		
+		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.DOMAINS, "(empty)", 
+				request, r -> this.cloudFoundryClient.domainsV3().list(request), this.requestTimeoutAppSummary);
 	}
-
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -13,8 +13,12 @@ import org.cloudfoundry.client.v2.applications.ListApplicationsRequest;
 import org.cloudfoundry.client.v2.applications.ListApplicationsResponse;
 import org.cloudfoundry.client.v2.info.GetInfoRequest;
 import org.cloudfoundry.client.v2.info.GetInfoResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesRequest;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.domains.ListDomainsRequest;
 import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.routes.ListRoutesRequest;
+import org.cloudfoundry.client.v3.routes.ListRoutesResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsRequest;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.organizations.OrganizationResource;
@@ -87,7 +91,13 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	private int requestTimeoutAppInSpace;
 	
 	@Value("${cf.request.timeout.appSummary:4000}")
-	private int requestTimeoutAppSummary;
+  private int requestTimeoutAppSummary;
+  
+  @Value("${cf.request.timeout.domains:4000}")
+  private int requestTimeoutDomains;
+
+  @Value("${cf.request.timeout.appRoutes:4000}")
+	private int requestTimeoutAppRoutes;
 	
 	@Value("${cf.connectionPool.size:#{null}}")
 	private Integer connectionPoolSize;
@@ -386,6 +396,14 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 		ListDomainsRequest request = ListDomainsRequest.builder().build();
 		
 		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.DOMAINS, "(empty)", 
-				request, r -> this.cloudFoundryClient.domainsV3().list(request), this.requestTimeoutAppSummary);
+				request, r -> this.cloudFoundryClient.domainsV3().list(request), this.requestTimeoutDomains);
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId) {
+    ListApplicationRoutesRequest request = ListApplicationRoutesRequest.builder().applicationId(appId).build();
+
+    return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.APP_ROUTES, appId, 
+      request, r -> this.cloudFoundryClient.applicationsV3().listRoutes(request), this.requestTimeoutAppRoutes);
 	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/RequestType.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/RequestType.java
@@ -8,6 +8,7 @@ public enum RequestType {
 	ALL_APPS_IN_SPACE("allApps", "retrieveAllApplicationIdsInSpace"),
   SPACE_SUMMARY("spaceSummary", "retrieveSpaceSummary"),
   DOMAINS("domains", "retrieveDomains"),
+  APP_ROUTES("appRoutes", "retrieveAppRoutes"),
 	OTHER("other", "other"); // used for unit testing only
 	
 	private final String metricName;

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/RequestType.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/RequestType.java
@@ -6,7 +6,8 @@ public enum RequestType {
 	SPACE("space", "retrieveSpaceId"),
 	SPACE_IN_ORG("space", "retrieveAllSpaceIdsInOrg"),
 	ALL_APPS_IN_SPACE("allApps", "retrieveAllApplicationIdsInSpace"),
-	SPACE_SUMMARY("spaceSummary", "retrieveSpaceSummary"),
+  SPACE_SUMMARY("spaceSummary", "retrieveSpaceSummary"),
+  DOMAINS("domains", "retrieveDomains"),
 	OTHER("other", "other"); // used for unit testing only
 	
 	private final String metricName;

--- a/src/main/java/org/cloudfoundry/promregator/scanner/Instance.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/Instance.java
@@ -9,18 +9,18 @@ public class Instance {
 	private ResolvedTarget target;
 	private String instanceId;
   private String accessUrl;
-  private boolean isInternal;
+  private boolean internal;
 	
 	public Instance() {
 		super();
 	}
 
 	public boolean isInternal() {
-		return isInternal;
+		return internal;
 	}
 
 	public void setInternal(boolean isInternal) {
-		this.isInternal = isInternal;
+		this.internal = isInternal;
 	}
 
 	public Instance(ResolvedTarget target, String instanceId, String accessUrl) {

--- a/src/main/java/org/cloudfoundry/promregator/scanner/Instance.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/Instance.java
@@ -8,10 +8,19 @@ package org.cloudfoundry.promregator.scanner;
 public class Instance {
 	private ResolvedTarget target;
 	private String instanceId;
-	private String accessUrl;
+  private String accessUrl;
+  private boolean isInternal;
 	
 	public Instance() {
 		super();
+	}
+
+	public boolean isInternal() {
+		return isInternal;
+	}
+
+	public void setInternal(boolean isInternal) {
+		this.isInternal = isInternal;
 	}
 
 	public Instance(ResolvedTarget target, String instanceId, String accessUrl) {

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
@@ -277,7 +277,7 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
       return Mono.just(v);
     });
     
-    Flux<GetDomainResponse> domainFlux = osaVectorApplicationRouteFlux.flatMapSequential(v -> this.cfAccessor.retrieveDomain(v.getDomainId()));
+		Flux<GetDomainResponse> domainFlux = osaVectorApplicationRouteFlux.flatMapSequential(v -> this.cfAccessor.retrieveDomain(v.getDomainId()));
 		Flux<OSAVector> osaVectorApplicationRouteDomainFlux = Flux.zip(osaVectorApplicationRouteFlux, domainFlux).flatMap(tuple -> {
 			OSAVector v = tuple.getT1();
 			
@@ -286,11 +286,11 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				return Mono.empty();
 			}
 			
-      GetDomainResponse domain = tuple.getT2();      
-      v.setInternal(domain.isInternal());      
-      return Mono.just(v);
-    });
-		
+			GetDomainResponse domain = tuple.getT2();      
+			v.setInternal(domain.isInternal());      
+			return Mono.just(v);
+		});
+	
 		// perform pre-filtering, if available
 		if (applicationIdFilter != null) {
 			osaVectorApplicationRouteDomainFlux = osaVectorApplicationRouteDomainFlux.filter(v -> applicationIdFilter.test(v.getApplicationId()));

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
@@ -152,13 +152,13 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
     /**
 		 * @return the isInternal
 		 */
-		public boolean getIsInternal() {
+		public boolean isInternal() {
 			return isInternal;
 		}
 		/**
 		 * @param isInternal the isInternal to set
 		 */
-		public void setIsInternal(boolean isInternal) {
+		public void setInternal(boolean isInternal) {
 			this.isInternal = isInternal;
 		}
 		/**
@@ -287,7 +287,7 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 			}
 			
       GetDomainResponse domain = tuple.getT2();      
-      v.setIsInternal(domain.isInternal());      
+      v.setInternal(domain.isInternal());      
       return Mono.just(v);
     });
 		

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
@@ -5,6 +5,7 @@ import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -61,6 +62,12 @@ public class CFAccessorCacheCaffeineSpringApplication {
 		@Override
 		public void reset() {
 			// nothing to be done
+		}
+
+		@Override
+		public Mono<ListDomainsResponse> retrieveDomains() {
+			// TODO Auto-generated method stub
+			return null;
 		}
 		
 	}

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
@@ -5,6 +5,7 @@ import org.cloudfoundry.client.v2.info.GetInfoResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.mockito.Mockito;
@@ -66,8 +67,12 @@ public class CFAccessorCacheCaffeineSpringApplication {
 
 		@Override
 		public Mono<ListDomainsResponse> retrieveDomains() {
-			// TODO Auto-generated method stub
-			return null;
+			return Mono.just(ListDomainsResponse.builder().build());
+		}
+
+		@Override
+		public Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId) {
+			return Mono.just(ListApplicationRoutesResponse.builder().build());
 		}
 		
 	}

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
@@ -6,7 +6,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
-import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.domains.GetDomainResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -66,8 +66,8 @@ public class CFAccessorCacheCaffeineSpringApplication {
 		}
 
 		@Override
-		public Mono<ListDomainsResponse> retrieveDomains() {
-			return Mono.just(ListDomainsResponse.builder().build());
+		public Mono<GetDomainResponse> retrieveDomain(String domainId) {
+			return Mono.just(GetDomainResponse.builder().build());
 		}
 
 		@Override

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
@@ -20,7 +20,7 @@ import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
-import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.domains.GetDomainResponse;
 import org.junit.jupiter.api.Assertions;
 
 import reactor.core.publisher.Mono;
@@ -164,7 +164,7 @@ public class CFAccessorMassMock implements CFAccessor {
 	}
 
 	@Override
-	public Mono<ListDomainsResponse> retrieveDomains() {
+	public Mono<GetDomainResponse> retrieveDomain(String domainId) {
     // TODO Auto-generated method stub    
 		return null;
 	}

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
@@ -19,6 +19,7 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
+import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.junit.jupiter.api.Assertions;
 
 import reactor.core.publisher.Mono;
@@ -159,5 +160,11 @@ public class CFAccessorMassMock implements CFAccessor {
 	@Override
 	public void reset() {
 		// nothing to be done
+	}
+
+	@Override
+	public Mono<ListDomainsResponse> retrieveDomains() {
+    // TODO Auto-generated method stub    
+		return null;
 	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
@@ -19,6 +19,7 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.junit.jupiter.api.Assertions;
 
@@ -165,6 +166,12 @@ public class CFAccessorMassMock implements CFAccessor {
 	@Override
 	public Mono<ListDomainsResponse> retrieveDomains() {
     // TODO Auto-generated method stub    
+		return null;
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId) {
+		// TODO Auto-generated method stub
 		return null;
 	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
@@ -18,6 +18,8 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
+import org.cloudfoundry.client.v3.domains.DomainResource;
+import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.junit.jupiter.api.Assertions;
 
 import reactor.core.publisher.Mono;
@@ -202,5 +204,13 @@ public class CFAccessorMock implements CFAccessor {
 	@Override
 	public void reset() {
 		// nothing to be done
+	}
+
+	@Override
+	public Mono<ListDomainsResponse> retrieveDomains() {    
+    ListDomainsResponse response = ListDomainsResponse.builder().resource(
+      DomainResource.builder().name("my.domain.com").build()
+    ).build();
+		return Mono.just(response);
 	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
@@ -44,7 +44,7 @@ public class CFAccessorMock implements CFAccessor {
   public static final String UNITTEST_INTERNAL_DOMAIN = "apps.internal";
   
   public static final String UNITTEST_APP_INTERNAL_UUID = "a8762694-95ce-4c3c-a4fb-250e28187a0a";
-  public static final String UNITTEST_APP_INTERNAL_HOST = "interna-app";
+  public static final String UNITTEST_APP_INTERNAL_HOST = "internal-app";
 	
 	public static final String CREATED_AT_TIMESTAMP = "2014-11-24T19:32:49+00:00";
 	public static final String UPDATED_AT_TIMESTAMP = "2014-11-24T19:32:49+00:00";

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
@@ -5,8 +5,6 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.management.relation.Relation;
-
 import org.cloudfoundry.client.v2.Metadata;
 import org.cloudfoundry.client.v2.applications.ApplicationEntity;
 import org.cloudfoundry.client.v2.applications.ApplicationResource;
@@ -24,8 +22,7 @@ import org.cloudfoundry.client.v3.Relationship;
 import org.cloudfoundry.client.v3.ToOneRelationship;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.domains.DomainRelationships;
-import org.cloudfoundry.client.v3.domains.DomainResource;
-import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.domains.GetDomainResponse;
 import org.cloudfoundry.client.v3.routes.Application;
 import org.cloudfoundry.client.v3.routes.Destination;
 import org.cloudfoundry.client.v3.routes.Process;
@@ -240,35 +237,42 @@ public class CFAccessorMock implements CFAccessor {
 	}
 
 	@Override
-	public Mono<ListDomainsResponse> retrieveDomains() {    
-    ListDomainsResponse response = ListDomainsResponse.builder().resources(
-      DomainResource.builder()
-        .name(UNITTEST_SHARED_DOMAIN)
-        .id(UNITTEST_SHARED_DOMAIN_UUID)
-        .createdAt(CREATED_AT_TIMESTAMP)
-        .isInternal(false)
-        .relationships(
-            DomainRelationships.builder()
-            .organization(
-              ToOneRelationship.builder()
-              .data(null).build()
-            ).build()
-          )
-        .build(),
-      DomainResource.builder()
-        .name(UNITTEST_INTERNAL_DOMAIN)
-        .id(UNITTEST_INTERNAL_DOMAIN_UUID)
-        .createdAt(CREATED_AT_TIMESTAMP)
-        .isInternal(true)
-        .relationships(
-            DomainRelationships.builder()
-            .organization(
-              ToOneRelationship.builder()
-              .data(null).build()
-            ).build()
-          )
-        .build()
-    ).build();
+	public Mono<GetDomainResponse> retrieveDomain(String domainId) {    
+    GetDomainResponse response;
+
+    if(domainId.equals(UNITTEST_INTERNAL_DOMAIN_UUID)) {  
+      response = GetDomainResponse.builder()
+      .name(UNITTEST_INTERNAL_DOMAIN)
+      .id(UNITTEST_INTERNAL_DOMAIN_UUID)
+      .createdAt(CREATED_AT_TIMESTAMP)
+      .isInternal(true)
+      .relationships(
+        DomainRelationships.builder()
+        .organization(
+          ToOneRelationship.builder()
+          .data(
+            Relationship.builder().id(UNITTEST_ORG_UUID).build()
+          ).build()
+        ).build()
+      )
+      .build();      
+    } else {
+      response = GetDomainResponse.builder()
+      .name(UNITTEST_SHARED_DOMAIN)
+      .id(UNITTEST_SHARED_DOMAIN_UUID)
+      .createdAt(CREATED_AT_TIMESTAMP)
+      .isInternal(false)
+      .relationships(
+        DomainRelationships.builder()
+        .organization(
+          ToOneRelationship.builder()
+          .data(
+            Relationship.builder().id(UNITTEST_ORG_UUID).build()
+          ).build()
+        ).build()
+      )
+      .build();      
+    }
 		return Mono.just(response);
 	}
 
@@ -282,12 +286,12 @@ public class CFAccessorMock implements CFAccessor {
       .createdAt(CREATED_AT_TIMESTAMP)
       .host(UNITTEST_APP_INTERNAL_HOST)    
       .path("path")
-      .url( UNITTEST_APP_INTERNAL_HOST + "." + UNITTEST_INTERNAL_DOMAIN)
+      .url(UNITTEST_APP_INTERNAL_HOST + "." + UNITTEST_INTERNAL_DOMAIN)
       .relationships(
         RouteRelationships.builder()
         .domain(
           ToOneRelationship.builder().data(
-            Relationship.builder().id(UNITTEST_INTERNAL_DOMAIN).build()
+            Relationship.builder().id(UNITTEST_INTERNAL_DOMAIN_UUID).build()
             ).build()
           )
           .space(
@@ -301,6 +305,70 @@ public class CFAccessorMock implements CFAccessor {
         .application(
           Application.builder()
           .applicationId(UNITTEST_APP_INTERNAL_UUID)
+          .process(
+            Process.builder().type("web").build()
+          ).build())
+        .build()
+      ).build();
+    
+      routes.add(res);
+    } else {
+      RouteResource res = RouteResource.builder()
+      .id("id")
+      .createdAt(CREATED_AT_TIMESTAMP)
+      .host(UNITTEST_APP1_HOST)    
+      .path("path")
+      .url(UNITTEST_APP1_HOST + "." + UNITTEST_SHARED_DOMAIN)
+      .relationships(
+        RouteRelationships.builder()
+        .domain(
+          ToOneRelationship.builder().data(
+            Relationship.builder().id(UNITTEST_SHARED_DOMAIN_UUID).build()
+            ).build()
+          )
+          .space(
+            ToOneRelationship.builder().data(
+              Relationship.builder().id(UNITTEST_SPACE_UUID).build()
+            ).build()
+          ).build())      
+      .destination(
+        Destination.builder()
+        .port(8080)
+        .application(
+          Application.builder()
+          .applicationId(UNITTEST_APP1_UUID)
+          .process(
+            Process.builder().type("web").build()
+          ).build())
+        .build()
+      ).build();
+    
+      routes.add(res);
+
+      res = RouteResource.builder()
+      .id("id")
+      .createdAt(CREATED_AT_TIMESTAMP)
+      .host(UNITTEST_APP2_HOST)    
+      .path("path")
+      .url(UNITTEST_APP2_HOST + "." + UNITTEST_SHARED_DOMAIN)
+      .relationships(
+        RouteRelationships.builder()
+        .domain(
+          ToOneRelationship.builder().data(
+            Relationship.builder().id(UNITTEST_SHARED_DOMAIN_UUID).build()
+            ).build()
+          )
+          .space(
+            ToOneRelationship.builder().data(
+              Relationship.builder().id(UNITTEST_SPACE_UUID).build()
+            ).build()
+          ).build())      
+      .destination(
+        Destination.builder()
+        .port(8080)
+        .application(
+          Application.builder()
+          .applicationId(UNITTEST_APP2_UUID)
           .process(
             Process.builder().type("web").build()
           ).build())

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.management.relation.Relation;
+
 import org.cloudfoundry.client.v2.Metadata;
 import org.cloudfoundry.client.v2.applications.ApplicationEntity;
 import org.cloudfoundry.client.v2.applications.ApplicationResource;
@@ -18,10 +20,17 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
 import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
+import org.cloudfoundry.client.v3.Relationship;
 import org.cloudfoundry.client.v3.ToOneRelationship;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.domains.DomainRelationships;
 import org.cloudfoundry.client.v3.domains.DomainResource;
 import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.routes.Application;
+import org.cloudfoundry.client.v3.routes.Destination;
+import org.cloudfoundry.client.v3.routes.Process;
+import org.cloudfoundry.client.v3.routes.RouteRelationships;
+import org.cloudfoundry.client.v3.routes.RouteResource;
 import org.junit.jupiter.api.Assertions;
 
 import reactor.core.publisher.Mono;
@@ -261,5 +270,47 @@ public class CFAccessorMock implements CFAccessor {
         .build()
     ).build();
 		return Mono.just(response);
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveAppRoutes(String appId) {
+    List<RouteResource> routes = new LinkedList<>();
+    
+    if(appId.equals(UNITTEST_APP_INTERNAL_UUID)) {
+      RouteResource res = RouteResource.builder()
+      .id("id")
+      .createdAt(CREATED_AT_TIMESTAMP)
+      .host(UNITTEST_APP_INTERNAL_HOST)    
+      .path("path")
+      .url( UNITTEST_APP_INTERNAL_HOST + "." + UNITTEST_INTERNAL_DOMAIN)
+      .relationships(
+        RouteRelationships.builder()
+        .domain(
+          ToOneRelationship.builder().data(
+            Relationship.builder().id(UNITTEST_INTERNAL_DOMAIN).build()
+            ).build()
+          )
+          .space(
+            ToOneRelationship.builder().data(
+              Relationship.builder().id(UNITTEST_SPACE_UUID).build()
+            ).build()
+          ).build())      
+      .destination(
+        Destination.builder()
+        .port(8080)
+        .application(
+          Application.builder()
+          .applicationId(UNITTEST_APP_INTERNAL_UUID)
+          .process(
+            Process.builder().type("web").build()
+          ).build())
+        .build()
+      ).build();
+    
+      routes.add(res);
+    }
+
+    ListApplicationRoutesResponse resp = ListApplicationRoutesResponse.builder().addAllResources(routes).build();
+		return Mono.just(resp);
 	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulatorTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulatorTest.java
@@ -6,6 +6,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
+import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -61,6 +62,17 @@ class CFAccessorSimulatorTest {
 		for (int i = 1;i<=10;i++) {
 			Assertions.assertTrue(tests[i]);
 		}
+  }
+  
+  @Test
+	void testRetrieveDomains() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		
+		Mono<ListDomainsResponse> mono = subject.retrieveDomains();
+		ListDomainsResponse result = mono.block();
+		
+		Assertions.assertNotNull(result);
+		Assertions.assertNotNull(result.getResources());
+		Assertions.assertEquals(10, result.getResources().size());	
 	}
-
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulatorTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulatorTest.java
@@ -6,7 +6,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceApplicationSummary;
-import org.cloudfoundry.client.v3.domains.ListDomainsResponse;
+import org.cloudfoundry.client.v3.domains.GetDomainResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -68,11 +68,10 @@ class CFAccessorSimulatorTest {
 	void testRetrieveDomains() {
 		CFAccessorSimulator subject = new CFAccessorSimulator(2);
 		
-		Mono<ListDomainsResponse> mono = subject.retrieveDomains();
-		ListDomainsResponse result = mono.block();
+		Mono<GetDomainResponse> mono = subject.retrieveDomain(CFAccessorSimulator.SHARED_DOMAIN_UUID);
+		GetDomainResponse result = mono.block();
 		
 		Assertions.assertNotNull(result);
-		Assertions.assertNotNull(result.getResources());
-		Assertions.assertEquals(10, result.getResources().size());	
+		Assertions.assertNotNull(result.getId());		
 	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScannerTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScannerTest.java
@@ -623,9 +623,9 @@ class ReactiveAppInstanceScannerTest {
     .extracting("isInternal").containsOnly(true);
 
     assertThat(result).filteredOn( instance -> instance.getInstanceId().equals(UNITTEST_APP_INTERNAL_UUID+":0") )
-    .extracting("accessUrl").containsOnly("http://0.internal-app.apps.internal:9090/metrics");
+    .extracting("accessUrl").containsOnly("http://0.internal-app.apps.internal:8080/metrics");
 
     assertThat(result).filteredOn( instance -> instance.getInstanceId().equals(UNITTEST_APP_INTERNAL_UUID+":1") )
-    .extracting("accessUrl").containsOnly("http://1.internal-app.apps.internal:9090/metrics");    
+    .extracting("accessUrl").containsOnly("http://1.internal-app.apps.internal:8080/metrics");    
 	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScannerTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScannerTest.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.promregator.scanner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.cloudfoundry.promregator.cfaccessor.CFAccessorMock.UNITTEST_APP1_UUID;
 import static org.cloudfoundry.promregator.cfaccessor.CFAccessorMock.UNITTEST_APP2_UUID;
+import static org.cloudfoundry.promregator.cfaccessor.CFAccessorMock.UNITTEST_APP_INTERNAL_UUID;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -599,5 +600,28 @@ class ReactiveAppInstanceScannerTest {
 
 		assertThat(result).filteredOn( instance -> instance.getInstanceId().equals(UNITTEST_APP2_UUID+":0") )
 				.extracting("accessUrl").containsOnly("https://hostapp2.shared.domain.example.org/additionalPath/testpath2");
+  }
+  
+
+  @Test
+	void testStraightForwardInternalRoute() {
+		List<ResolvedTarget> targets = new LinkedList<>();
+		
+		ResolvedTarget t = new ResolvedTarget();
+		t.setOrgName("unittestorg");
+		t.setSpaceName("unittestspace");
+		t.setApplicationName("internalapp");		
+		t.setProtocol("http");
+		t.setApplicationId(UNITTEST_APP_INTERNAL_UUID);
+		final Target emptyTarget = new Target();
+		t.setOriginalTarget(emptyTarget);
+		targets.add(t);
+		
+
+		
+    List<Instance> result = this.appInstanceScanner.determineInstancesFromTargets(targets, null, null);
+    
+    assertThat(result).filteredOn( instance -> instance.getInstanceId().equals(UNITTEST_APP_INTERNAL_UUID+":0") )
+    .extracting("isInternal").containsOnly(true);
 	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScannerTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScannerTest.java
@@ -616,12 +616,16 @@ class ReactiveAppInstanceScannerTest {
 		final Target emptyTarget = new Target();
 		t.setOriginalTarget(emptyTarget);
 		targets.add(t);
-		
-
-		
+				
     List<Instance> result = this.appInstanceScanner.determineInstancesFromTargets(targets, null, null);
     
     assertThat(result).filteredOn( instance -> instance.getInstanceId().equals(UNITTEST_APP_INTERNAL_UUID+":0") )
     .extracting("isInternal").containsOnly(true);
+
+    assertThat(result).filteredOn( instance -> instance.getInstanceId().equals(UNITTEST_APP_INTERNAL_UUID+":0") )
+    .extracting("accessUrl").containsOnly("http://0.internal-app.apps.internal:9090/metrics");
+
+    assertThat(result).filteredOn( instance -> instance.getInstanceId().equals(UNITTEST_APP_INTERNAL_UUID+":1") )
+    .extracting("accessUrl").containsOnly("http://1.internal-app.apps.internal:9090/metrics");    
 	}
 }


### PR DESCRIPTION
This is a Work in Progress to show my approach and get feedback.


## Current Situation

Promregator does not currently support routing for internal domains. This PR intends to add support for detecting an internal domain and providing the correct internal urls. See #190 for more info

## Problem Statement
I would like to use promregator with internal routes to keep metrics scraping private and use alternative ports on my apps for metrics servers.

## Solution Approach
<!-- Summarize the solution you propose. Don't go on detailed level (that's what the 'diff' of the PR is for already), but describe the overall idea that you suggest. 
If possible, explain why you did so. Mention alternatives that you have considered, but discarded (if possible given the reason for that). -->
- Add retrieval of the available domains from CF
- when detecting the URL for a target match it to a domain
- if the domain is internal use the internal url scheme
- use the port defined in the route for the scraping port

i looks like in the api when you retrieve routes for an app you can see the port that has been mapped there. Even though you have to explicitly use the port in the URL when using an internal route.


