### PR TITLE
Support CF-for-k8s like metrics using Kubernetes based annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Here is the list of major features provided by Promregator:
 * [Additional metrics are provided](docs/enrichment.md) supporting you to **monitor Promregator** and the **communication to the Cloud Foundry applications**.
 * *(>= 0.4.0)* **[Cache Invalidation](docs/invalidate-cache.md)** is possible via an (optionally auth-protected) HTTP REST endpoint.
 * Promregator's endpoints (e.g. `/metrics`, `/promregatorMetrics`, `/discovery`) support **GZIP compression**, if the clients indicates to accept it.
+* Filtering by annotations and using annotations to specify the metrics path.
 
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Here is the list of major features provided by Promregator:
   The available authentication schemes are easily extensible.
   
   *(>= 0.4.0)* Each target may be configured to use its own authentication scheme, thus you may authenticate to multiple CF apps using different credentials.
+  *(>= 0.9.0)* Ability to specify the [SSL Context](docs/mtls-ssl-contexts.md) used by promregator using JVM options
 * *(>= 0.2.0)* **Support for inbound authentication** (e.g. Prometheus authenticates to Promregator) using Basic HTTP Authentication. 
 * **Configuration using standard Spring properties** as defined by the Spring Framework (e.g. using `application.yml` file).
 * *(>= 0.6.0)* Support for [**encrypted passwords in configuration files**](./docs/passwords-in-config.md) including providing the encryption key via **Docker Secrets**
@@ -61,7 +62,6 @@ Here is the list of major features provided by Promregator:
 * *(>= 0.4.0)* **[Cache Invalidation](docs/invalidate-cache.md)** is possible via an (optionally auth-protected) HTTP REST endpoint.
 * Promregator's endpoints (e.g. `/metrics`, `/promregatorMetrics`, `/discovery`) support **GZIP compression**, if the clients indicates to accept it.
 * *(>= 0.9.0)* [Filtering by annotations](docs/annotation-driven.md) and using annotations to specify the metrics path.
-* *(>= 0.9.0)* Ability to specify the [SSL Context](docs/mtls-ssl-contexts.md) used by promregator using JVM options
 
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Here is the list of major features provided by Promregator:
 * [Additional metrics are provided](docs/enrichment.md) supporting you to **monitor Promregator** and the **communication to the Cloud Foundry applications**.
 * *(>= 0.4.0)* **[Cache Invalidation](docs/invalidate-cache.md)** is possible via an (optionally auth-protected) HTTP REST endpoint.
 * Promregator's endpoints (e.g. `/metrics`, `/promregatorMetrics`, `/discovery`) support **GZIP compression**, if the clients indicates to accept it.
-* Filtering by annotations and using annotations to specify the metrics path.
+* *(>= 0.9.0)* Filtering by annotations and using annotations to specify the metrics path.
 
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Here is the list of major features provided by Promregator:
 * [Additional metrics are provided](docs/enrichment.md) supporting you to **monitor Promregator** and the **communication to the Cloud Foundry applications**.
 * *(>= 0.4.0)* **[Cache Invalidation](docs/invalidate-cache.md)** is possible via an (optionally auth-protected) HTTP REST endpoint.
 * Promregator's endpoints (e.g. `/metrics`, `/promregatorMetrics`, `/discovery`) support **GZIP compression**, if the clients indicates to accept it.
-* *(>= 0.9.0)* Filtering by annotations and using annotations to specify the metrics path.
+* *(>= 0.9.0)* [Filtering by annotations](docs/annotation-driven.md) and using annotations to specify the metrics path.
+* *(>= 0.9.0)* Ability to specify the [SSL Context](docs/mtls-ssl-contexts.md) used by promregator using JVM options
 
 
 ## Architecture

--- a/docs/annotation-driven.md
+++ b/docs/annotation-driven.md
@@ -1,0 +1,33 @@
+# Annotation-Driven Configuration
+
+Starting with version 0.9.0 of Promregator, annotation-driven configuration of targets is supported if the underlying Cloud Foundry platform supports the CAPI V3 interface. Note that in these days the latter should not be a challenging requirement given the fact that the former interface, CAPI V2, has been deprecated.
+
+Configuration follows the approach suggested by [cf-for-k8s](https://github.com/cloudfoundry/cf-for-k8s-metric-examples). See also that page fro examples how to set annotations.
+
+These annotations are supported:
+
+| Annotation | supported | Comments |
+|------------|-----------|----------|
+| `prometheus.io/scrape` | yes | must be set to `"true"` |
+| `prometheus.io/path` | yes | overwrites any other `path` attribute in Promregator's main configuration, if provided |
+| `prometheus.io/port` | no | |
+
+For the metadata to be evaluated, the corresponding target needs to have set the attribute `kubernetesAnnotations` to `true` (see also details at the [configuration option page](./config.md) for this option). Note that if this option is set, any target which does *not* provide the necessary metadata annotations will not be selected for scraping (but ignored).
+
+## Example application
+
+An example Cloud Foundry application using these annotations would be deployed
+using a sample manifest like below:
+
+```yaml
+---
+applications:
+- name: go-app-with-metrics
+  metadata:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/path: "/not/default/metrics"
+```
+
+Given this configuration, the app would be scraped by promregator and the path
+for scraping would be `/not/default/metrics`.

--- a/docs/annotation-driven.md
+++ b/docs/annotation-driven.md
@@ -14,6 +14,8 @@ These annotations are supported:
 
 For the metadata to be evaluated, the corresponding target needs to have set the attribute `kubernetesAnnotations` to `true` (see also details at the [configuration option page](./config.md) for this option). Note that if this option is set, any target which does *not* provide the necessary metadata annotations will not be selected for scraping (but ignored).
 
+This provides the opportunity for an "opt-in" to scraping by applications without the need of modifying Promregator's configuration: If another application wants to get scraped, it may set `prometheus.io/scrape` to `true` (and provide a `prometheus.io/path` if applicable). On the next metadata update, the new application will be detected automatically and added to discovery.
+
 ## Example application
 
 An example Cloud Foundry application using these annotations would be deployed

--- a/docs/config.md
+++ b/docs/config.md
@@ -429,6 +429,16 @@ Defaults to `/metrics`, as this is the value which is suggested by Prometheus.
 
 Note that there may be frameworks out there, which expose their metrics in a different format using the same path `/metrics`, though. 
 
+#### Item property "promregator.targets[].kubernetesAnnotations" (optional)
+Enables support for the de facto standard Kubernetes Prometheus annotations on your CF applications. This allows each application to "opt-in" to scraping
+by specifying the annotation `prometheus.io/scrape: "true"`. Annotations support requires a version of Cloud Foundry with the V3 API otherwise this setting will be ignored. 
+
+For an example on deploying an app with these annotations see [here](https://github.com/cloudfoundry/cf-for-k8s-metric-examples).
+
+Defaults to `false`. Enabling this feature will override the `promregator.targets[].path` when it is specified using the annotation `prometheus.io/path: "/some/other/metrics"`
+
+Does not currently support the `prometheus.io/port` annotation.
+
 #### Item property "promregator.targets[].protocol" (optional)
 Specifies the protocol (`http` or `https`) which shall be used to retrieve the metrics.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -427,7 +427,8 @@ Note that the data returned by this endpoint of the target must comply to the [T
 
 Defaults to `/metrics`, as this is the value which is suggested by Prometheus.
 
-Note that there may be frameworks out there, which expose their metrics in a different format using the same path `/metrics`, though. 
+Note that there may be frameworks out there, which expose their metrics in a different format using the same path `/metrics`, though.
+Note that setting `promregator.targets[].kubernetesAnnotations` to `true` will cause that any value set to this parameter is ignored by applications that have annotation `prometheus.io/path` set.
 
 #### Item property "promregator.targets[].kubernetesAnnotations" (optional)
 Enables support for the de facto standard Kubernetes Prometheus annotations on your CF applications. This allows each application to "opt-in" to scraping

--- a/docs/mtls-ssl-contexts.md
+++ b/docs/mtls-ssl-contexts.md
@@ -1,0 +1,38 @@
+# SSL Contexts in Promregator
+
+Promregator supports using system properties to specify SSL Contexts used for
+outgoing communications to scrape targets. The SSL Context is specified on the JVM
+level and thus cannot differ between targets. It will be applied to all targets.
+
+The ability to configure an SSL Context allows Promregator to negotiate mTLS to targets
+and verify their certificates if signed by an alternate CA.
+
+## Prerequisites
+
+- You have a keystore containing the client certificate for Promregator to use for
+outgoing communications
+  
+- You have a Java truststore containing your CA
+
+## Specifying an SSL Context
+
+To start Promregator with an SSL Context you simply pass arguments to the JVM.
+
+### Supported Properties:
+- `javax.net.ssl.keyStore` The path to the Java keystore file containing the processes
+own certificate and private key.
+  
+- `javax.net.ssl.keyStorePassword` Password to access the keystore
+
+- `javax.net.ssl.trustStore` The path to the Java trust store file containing the CA
+certificates that Promregator should trust
+  
+- `javax.net.ssl.trustStorePassword` Password to access the trust store
+
+- `javax.net.debug` Optionally set this to `ssl` to enable logging for the SSL/TLS layer
+
+### Example
+
+```shell
+java -Djavax.net.ssl.keyStore=/home/example/key.jks -Djavax.net.ssl.keyStorePassword=example -Djavax.net.ssl.trustStore=/home/example/trust.jks -Djavax.net.ssl.trustStorePassword=example
+```

--- a/docs/mtls-ssl-contexts.md
+++ b/docs/mtls-ssl-contexts.md
@@ -12,7 +12,7 @@ and verify their certificates if signed by an alternate CA.
 - You have a keystore containing the client certificate for Promregator to use for
 outgoing communications
   
-- You have a Java truststore containing your CA
+- You have a Java trust store containing your CA
 
 ## Specifying an SSL Context
 
@@ -35,4 +35,9 @@ certificates that Promregator should trust
 
 ```shell
 java -Djavax.net.ssl.keyStore=/home/example/key.jks -Djavax.net.ssl.keyStorePassword=example -Djavax.net.ssl.trustStore=/home/example/trust.jks -Djavax.net.ssl.trustStorePassword=example
+```
+
+If using the docker container you can specify these options using the `JAVA_OPTS` environment variable
+```shell
+docker run -e JAVA_OPTS='-Djavax.net.ssl.keyStore...' ...
 ```

--- a/src/main/java/org/cloudfoundry/promregator/PromregatorApplication.java
+++ b/src/main/java/org/cloudfoundry/promregator/PromregatorApplication.java
@@ -17,7 +17,6 @@ import org.cloudfoundry.promregator.cfaccessor.CFAccessorSimulator;
 import org.cloudfoundry.promregator.cfaccessor.CFWatchdog;
 import org.cloudfoundry.promregator.cfaccessor.ReactiveCFAccessorImpl;
 import org.cloudfoundry.promregator.config.ConfigurationValidations;
-import org.cloudfoundry.promregator.config.validations.CompatibleCAPIVersion;
 import org.cloudfoundry.promregator.discovery.CFMultiDiscoverer;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.cloudfoundry.promregator.lifecycle.InstanceLifecycleHandler;

--- a/src/main/java/org/cloudfoundry/promregator/PromregatorApplication.java
+++ b/src/main/java/org/cloudfoundry/promregator/PromregatorApplication.java
@@ -17,6 +17,7 @@ import org.cloudfoundry.promregator.cfaccessor.CFAccessorSimulator;
 import org.cloudfoundry.promregator.cfaccessor.CFWatchdog;
 import org.cloudfoundry.promregator.cfaccessor.ReactiveCFAccessorImpl;
 import org.cloudfoundry.promregator.config.ConfigurationValidations;
+import org.cloudfoundry.promregator.config.validations.CompatibleCAPIVersion;
 import org.cloudfoundry.promregator.discovery.CFMultiDiscoverer;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.cloudfoundry.promregator.lifecycle.InstanceLifecycleHandler;

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
@@ -7,6 +7,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import reactor.core.publisher.Mono;
 
 public interface CFAccessor {
@@ -25,6 +26,22 @@ public interface CFAccessor {
 	Mono<GetSpaceSummaryResponse> retrieveSpaceSummary(String spaceId);	
 
 	Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId);
+
+	Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName);
+
+	Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3();
+
+	Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName);
+
+	Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId);
+
+	Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId);
+
+	Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId);
+
+	Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId);
+
+	Mono<org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId);
 	
 	void reset();
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
@@ -35,7 +35,7 @@ public interface CFAccessor {
 
 	Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId);
 
-	Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId);
+	Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId);
 
 	Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId);
 

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessor.java
@@ -42,6 +42,8 @@ public interface CFAccessor {
 	Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId);
 
 	Mono<org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId);
+
+	boolean isV3Enabled();
 	
 	void reset();
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
@@ -14,6 +14,8 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -263,6 +265,53 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 	@Override
 	public Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId) {
 		return Mono.fromFuture(this.domainsInOrgCache.get(orgId));
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		// TODO: Implement cache
+		return this.parent.retrieveOrgIdV3(orgName);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		// TODO: Implement cache
+		return this.parent.retrieveAllOrgIdsV3();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceIdV3(orgId, spaceName);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceIdsInOrgV3(orgId);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		// TODO: Implement cache
+		return this.parent.retrieveAllApplicationIdsInSpaceV3(orgId, spaceId);
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceV3(spaceId);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		// TODO: Implement cache
+		return this.parent.retrieveAllDomainsV3(orgId);
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
@@ -341,6 +341,7 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 		
 		this.appsInSpaceCache.synchronous().invalidateAll();
 		this.spaceSummaryCache.synchronous().invalidateAll();
+		this.appsInSpaceV3Cache.synchronous().invalidateAll();
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeine.java
@@ -336,6 +336,11 @@ public class CFAccessorCacheCaffeine implements CFAccessorCache {
 	}
 
 	@Override
+	public boolean isV3Enabled() {
+		return this.parent.isV3Enabled();
+	}
+
+	@Override
 	public void invalidateCacheApplications() {
 		log.info("Invalidating application cache");
 		

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
@@ -30,6 +30,7 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	private AutoRefreshingCacheMap<CacheKeyAppsInSpace, Mono<ListApplicationsResponse>> appsInSpaceCache;
 	private AutoRefreshingCacheMap<String, Mono<GetSpaceSummaryResponse>> spaceSummaryCache;	
 	private AutoRefreshingCacheMap<String, Mono<ListOrganizationDomainsResponse>> domainCache;
+	private AutoRefreshingCacheMap<CacheKeyAppsInSpace, Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse>> appsInSpaceV3Cache;
 
 	@Value("${cf.cache.timeout.org:3600}")
 	private int refreshCacheOrgLevelInSeconds;
@@ -79,6 +80,7 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 		this.appsInSpaceCache = new AutoRefreshingCacheMap<>("appsInSpace", this.internalMetrics, Duration.ofSeconds(this.expiryCacheApplicationLevelInSeconds), Duration.ofSeconds(refreshCacheApplicationLevelInSeconds), this::appsInSpaceCacheLoader);
 		this.spaceSummaryCache = new AutoRefreshingCacheMap<>("spaceSummary", this.internalMetrics, Duration.ofSeconds(this.expiryCacheApplicationLevelInSeconds), Duration.ofSeconds(refreshCacheApplicationLevelInSeconds), this::spaceSummaryCacheLoader);		
 		this.domainCache = new AutoRefreshingCacheMap<>("routeMappings", this.internalMetrics, Duration.ofSeconds(this.expiryCacheDomainLevelInSeconds), Duration.ofSeconds(refreshCacheDomainLevelInSeconds), this::domainCacheLoader);
+		this.appsInSpaceV3Cache = new AutoRefreshingCacheMap<>("appsInSpaceV3", this.internalMetrics, Duration.ofSeconds(this.expiryCacheApplicationLevelInSeconds), Duration.ofSeconds(refreshCacheApplicationLevelInSeconds), this::appsInSpaceV3CacheLoader);
 	}
 
 	private Mono<ListOrganizationsResponse> orgCacheLoader(String orgName) {
@@ -399,6 +401,70 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 		return mono;
   	}
 
+	private Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> appsInSpaceV3CacheLoader(CacheKeyAppsInSpace cacheKey) {
+		Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> mono = this.parent.retrieveAllApplicationsInSpaceV3(cacheKey.getOrgId(), cacheKey.getSpaceId()).cache();
+
+
+		/*
+		 * Note that the mono does not have any subscriber, yet!
+		 * The cache which we are using is working "on-stock", i.e. we need to ensure
+		 * that the underlying calls to the CF API really is triggered.
+		 * Fortunately, we can do this very easily:
+		 */
+		mono.subscribe();
+
+		/*
+		 * Handling for issue #96: If a timeout of the request to the  CF Cloud Controller occurs,
+		 * we must make sure that the erroneous Mono is not kept in the cache. Instead we have to displace the item,
+		 * which triggers a refresh of the cache.
+		 *
+		 * Note that subscribe() must be called *before* adding this error handling below.
+		 * Otherwise we will run into the situation that the error handling routine is called by this
+		 * subscribe() already - but the Mono has not been written into the cache yet!
+		 * If we do it in this order, the doOnError method will only be called once the first "real subscriber"
+		 * of the Mono will start requesting.
+		 */
+		mono = mono.doOnError(e -> {
+			if (e instanceof TimeoutException) {
+				log.warn(String.format("Timed-out entry using key %s detected, which would get stuck in our appsInSpace cache; "
+										   + "displacing it now to prevent further harm", cacheKey), e);
+				/*
+				 * Note that it *might* happen that a different Mono gets displaced than the one we are in here now.
+				 * Yet, we can't make use of the
+				 *
+				 * remove(key, value)
+				 *
+				 * method, as providing value would lead to a hen-egg problem (we were required to provide the reference
+				 * of the Mono instance, which we are just creating).
+				 * Instead, we just blindly remove the entry from the cache. This may lead to four cases to consider:
+				 *
+				 * 1. We hit the correct (erroneous) entry: then this is exactly what we want to do.
+				 * 2. We hit another erroneous entry: then we have no harm done, because we fixed yet another case.
+				 * 3. We hit a healthy entry: Bad luck; on next iteration, we will get a cache miss, which automatically
+				 *    fixes the issue (as long this does not happen too often, ...)
+				 * 4. The entry has already been deleted by someone else: the remove(key) operation will
+				 *    simply be a NOOP. => no harm done either.
+				 */
+				this.appsInSpaceV3Cache.remove(cacheKey);
+
+				// Notify metrics of this case
+				if (this.internalMetrics != null) {
+					this.internalMetrics.countAutoRefreshingCacheMapErroneousEntriesDisplaced(this.appsInSpaceV3Cache.getName());
+				}
+			}
+		});
+		/*
+		 * Keep in mind that doOnError is a side-effect:  The logic above only removes it from the cache.
+		 * The erroneous instance still is used downstream and will trigger subsequent error handling (including
+		 * logging) there.
+		 * Note that this also holds true during the timeframe of the timeout: This instance of the Mono will
+		 * be written to the cache, thus all consumers of the cache will be handed out the cached, not-yet-resolved
+		 * object instance. This implicitly makes sure that there can only be one valid pending request is out there.
+		 */
+
+		return mono;
+	}
+
 
 	@Override
 	public Mono<GetInfoResponse> getInfo() {
@@ -479,9 +545,10 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	}
 
 	@Override
-	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
-		// TODO: Implement cache
-		return this.parent.retrieveAllApplicationIdsInSpaceV3(orgId, spaceId);
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
+		final CacheKeyAppsInSpace key = new CacheKeyAppsInSpace(orgId, spaceId);
+
+		return this.appsInSpaceV3Cache.get(key);
 	}
 
 	@Override
@@ -505,6 +572,7 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	public void invalidateCacheApplications() {
 		log.info("Invalidating application cache");
 		this.spaceSummaryCache.clear();
+		this.appsInSpaceV3Cache.clear();
 		// TODO why is appsInSpaceCache not cleared here?
 	}
 	

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
@@ -11,6 +11,8 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.cache.AutoRefreshingCacheMap;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.slf4j.Logger;
@@ -450,6 +452,53 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	@Override
 	public Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId) {
 		return this.domainCache.get(orgId);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		// TODO: Implement cache
+		return this.parent.retrieveOrgIdV3(orgName);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		// TODO: Implement cache
+		return this.parent.retrieveAllOrgIdsV3();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceIdV3(orgId, spaceName);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceIdsInOrgV3(orgId);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		// TODO: Implement cache
+		return this.parent.retrieveAllApplicationIdsInSpaceV3(orgId, spaceId);
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		// TODO: Implement cache
+		return this.parent.retrieveSpaceV3(spaceId);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		// TODO: Implement cache
+		return this.parent.retrieveAllDomainsV3(orgId);
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassic.java
@@ -569,6 +569,11 @@ public class CFAccessorCacheClassic implements CFAccessorCache {
 	}
 
 	@Override
+	public boolean isV3Enabled() {
+		return this.parent.isV3Enabled();
+	}
+
+	@Override
 	public void invalidateCacheApplications() {
 		log.info("Invalidating application cache");
 		this.spaceSummaryCache.clear();

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
@@ -31,6 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
+import static org.cloudfoundry.promregator.cfaccessor.ReactiveCFAccessorImpl.INVALID_APPLICATIONS_RESPONSE;
+
 public class CFAccessorSimulator implements CFAccessor {
 	public static final String ORG_UUID = "eb51aa9c-2fa3-11e8-b467-0ed5f89f718b";
 	public static final String SPACE_UUID = "db08be9a-2fa4-11e8-b467-0ed5f89f718b";
@@ -245,8 +247,8 @@ public class CFAccessorSimulator implements CFAccessor {
 	}
 
 	@Override
-	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
-		throw new UnsupportedOperationException();
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
+		return Mono.just(INVALID_APPLICATIONS_RESPONSE);
 	}
 
 	@Override

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
@@ -25,6 +25,8 @@ import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.domains.Domain;
 import org.cloudfoundry.client.v2.domains.DomainEntity;
 import org.cloudfoundry.client.v2.domains.DomainResource;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -220,5 +222,45 @@ public class CFAccessorSimulator implements CFAccessor {
 		
 		ListOrganizationDomainsResponse response = ListOrganizationDomainsResponse.builder().addAllResources(domains).build();
 		return Mono.just(response);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulator.java
@@ -265,4 +265,9 @@ public class CFAccessorSimulator implements CFAccessor {
 	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
 		throw new UnsupportedOperationException();
 	}
+
+	@Override
+	public boolean isV3Enabled() {
+		return true;
+	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/PaginatedRequestGeneratorFunctionV3.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/PaginatedRequestGeneratorFunctionV3.java
@@ -1,0 +1,9 @@
+package org.cloudfoundry.promregator.cfaccessor;
+
+import org.cloudfoundry.client.v3.PaginatedRequest;
+
+@FunctionalInterface
+public interface PaginatedRequestGeneratorFunctionV3<T extends PaginatedRequest> {
+	// for the idea, see also https://stackoverflow.com/a/27872395 
+	T apply(int resultsPerPage, int pageNumber);
+}

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/PaginatedResponseGeneratorFunctionV3.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/PaginatedResponseGeneratorFunctionV3.java
@@ -1,0 +1,11 @@
+package org.cloudfoundry.promregator.cfaccessor;
+
+import org.cloudfoundry.client.v3.PaginatedResponse;
+
+import java.util.List;
+
+@FunctionalInterface
+public interface PaginatedResponseGeneratorFunctionV3<S, T extends PaginatedResponse<?>> {
+	// for the idea, see also https://stackoverflow.com/a/27872395 
+	T apply(List<S> data, int numberOfPages);
+}

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -23,6 +23,10 @@ import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesRequest;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
+import org.cloudfoundry.client.v3.Pagination;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceRequest;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.config.ConfigurationException;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.cloudfoundry.reactor.ConnectionContext;
@@ -42,7 +46,8 @@ import reactor.core.publisher.Mono;
 public class ReactiveCFAccessorImpl implements CFAccessor {
 
 	private static final Logger log = LoggerFactory.getLogger(ReactiveCFAccessorImpl.class);
-	
+	private boolean v3Enabled;
+
 	@Value("${cf.api_host}")
 	private String apiHost;
 
@@ -220,6 +225,14 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 			
 			log.info("Target CF platform is running on API version {}", apiVersion);
 		}
+
+		String getRoot = this.cloudFoundryClient.getRootV3().block();
+		// Ensures v3 API exists
+
+		if (getRoot == null) {
+			log.warn("unable to get v3 endpoint of CF platform");
+			this.v3Enabled = false;
+		}
 	}
 
 	@Override
@@ -258,6 +271,10 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 	private void setupPaginatedRequestFetcher() {
 		this.paginatedRequestFetcher = new ReactiveCFPaginatedRequestFetcher(this.internalMetrics, this.requestRateLimit, 
 				Duration.ofMillis(this.backoffDelay));
+	}
+
+	public boolean isV3Enabled() {
+		return this.v3Enabled;
 	}
 	
 	private static final GetInfoRequest DUMMY_GET_INFO_REQUEST = GetInfoRequest.builder().build();
@@ -391,5 +408,115 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 
 		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.DOMAINS, orgId, 
 		request, r -> this.cloudFoundryClient.organizations().listDomains(request), this.requestTimeoutDomains);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		// Note: even though we use the List request here, the number of values returned is either zero or one
+		// ==> No need for a paged request.
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest orgsRequest = org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest.builder().name(orgName).build();
+
+		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.ORG, orgName, orgsRequest,
+																	or -> this.cloudFoundryClient.organizationsV3()
+																								 .list(or), this.requestTimeoutOrg);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest> requestGenerator = (resultsPerPage, pageNumber) ->
+			org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest.builder()
+									.perPage(resultsPerPage)
+									.page(pageNumber)
+									.build();
+
+		PaginatedResponseGeneratorFunctionV3<org.cloudfoundry.client.v3.organizations.OrganizationResource, org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> responseGenerator = (list, numberOfPages) ->
+			org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder()
+									 .addAllResources(list)
+									 .pagination(Pagination.builder().totalPages(numberOfPages).totalResults(list.size()).build())
+									 .build();
+
+		return this.paginatedRequestFetcher.performGenericPagedRetrievalV3(RequestType.ALL_ORGS, "(empty)", requestGenerator,
+																		 r -> this.cloudFoundryClient.organizationsV3().list(r),  this.requestTimeoutOrg, responseGenerator);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		// Note: even though we use the List request here, the number of values returned is either zero or one
+		// ==> No need for a paged request.
+
+		String key = String.format("%s|%s", orgId, spaceName);
+
+		org.cloudfoundry.client.v3.spaces.ListSpacesRequest spacesRequest = org.cloudfoundry.client.v3.spaces.ListSpacesRequest.builder().organizationId(orgId).name(spaceName).build();
+
+		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.SPACE, key, spacesRequest, sr ->
+																		this.cloudFoundryClient.spacesV3().list(sr),
+																	this.requestTimeoutSpace);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.spaces.ListSpacesRequest> requestGenerator = (resultsPerPage, pageNumber) ->
+			org.cloudfoundry.client.v3.spaces.ListSpacesRequest.builder()
+							 .organizationId(orgId)
+							 .perPage(resultsPerPage)
+							 .page(pageNumber)
+							 .build();
+
+		PaginatedResponseGeneratorFunctionV3<org.cloudfoundry.client.v3.spaces.SpaceResource, org.cloudfoundry.client.v3.spaces.ListSpacesResponse> responseGenerator = (list, numberOfPages) ->
+			org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder()
+							  .addAllResources(list)
+							  .pagination(Pagination.builder().totalPages(numberOfPages).totalResults(list.size()).build())
+							  .build();
+
+
+		return this.paginatedRequestFetcher.performGenericPagedRetrievalV3(RequestType.SPACE_IN_ORG, orgId, requestGenerator,
+																		 r -> this.cloudFoundryClient.spacesV3().list(r),  this.requestTimeoutSpace, responseGenerator);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		String key = String.format("%s|%s", orgId, spaceId);
+
+		PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.applications.ListApplicationsRequest> requestGenerator = (resultsPerPage, pageNumber) ->
+			org.cloudfoundry.client.v3.applications.ListApplicationsRequest.builder()
+								   .organizationId(orgId)
+								   .spaceId(spaceId)
+								   .perPage(resultsPerPage)
+								   .page(pageNumber)
+								   .build();
+
+		PaginatedResponseGeneratorFunctionV3<org.cloudfoundry.client.v3.applications.ApplicationResource, org.cloudfoundry.client.v3.applications.ListApplicationsResponse> responseGenerator = (list, numberOfPages) ->
+			org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder()
+									.addAllResources(list)
+									.pagination(Pagination.builder().totalPages(numberOfPages).totalResults(list.size()).build())
+									.build();
+
+		return this.paginatedRequestFetcher.performGenericPagedRetrievalV3(RequestType.ALL_APPS_IN_SPACE, key, requestGenerator,
+																		 r -> this.cloudFoundryClient.applicationsV3().list(r), this.requestTimeoutAppInSpace, responseGenerator);
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		// This API has drastically changed in v3 and does not support the same resources. This call for a space summary will probably
+		// take another call to list applications for a space, list routes for the apps, and list domains in the org
+		// Previously they were all grouped into this API
+
+		GetSpaceRequest request = GetSpaceRequest.builder().spaceId(spaceId).build();
+
+		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.SPACE_SUMMARY, spaceId,
+																	request, r -> this.cloudFoundryClient.spacesV3().get(r), this.requestTimeoutAppSummary);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsRequest request = org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsRequest.builder().organizationId(orgId).build();
+
+		return this.paginatedRequestFetcher.performGenericRetrieval(RequestType.DOMAINS, orgId,
+																	request, r -> this.cloudFoundryClient.organizationsV3().listDomains(request), this.requestTimeoutDomains);
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFAccessorImpl.java
@@ -236,7 +236,7 @@ public class ReactiveCFAccessorImpl implements CFAccessor {
 			.get().onErrorReturn(JsonNodeFactory.instance.nullNode()).block();
 
 		if (v3Info == null || v3Info.isNull()) {
-			log.warn("unable to get v3 info endpoint of CF platform");
+			log.warn("unable to get v3 info endpoint of CF platform, some features will not work as expected");
 			this.v3Enabled = false;
 		} else {
 			this.v3Enabled = true;

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcher.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcher.java
@@ -31,7 +31,7 @@ class ReactiveCFPaginatedRequestFetcher {
 	private static final int RESULTS_PER_PAGE = MAX_SUPPORTED_RESULTS_PER_PAGE;
 
 	private InternalMetrics internalMetrics;
-	
+
 	private final RateLimiter cfccRateLimiter;
 
 	private final Duration initialBackoffDelay;
@@ -40,62 +40,63 @@ class ReactiveCFPaginatedRequestFetcher {
 		super();
 		this.internalMetrics = internalMetrics;
 		this.initialBackoffDelay = backoffDelay;
-		
+
 		if (requestRateLimit <= 0.0f) {
 			this.cfccRateLimiter = RateLimiter.create(Double.POSITIVE_INFINITY);
-		} else {
+		}
+		else {
 			this.cfccRateLimiter = RateLimiter.create(requestRateLimit);
 		}
 	}
 
 	/**
-	 * Returns an empty Mono, which is only resolved after the configured rate limit
-	 * could be acquired.
-	 * @param requestType the RequestType for which the rate limiting shall be acquired (mainly for statistical purpose only)
+	 * Returns an empty Mono, which is only resolved after the configured rate limit could be acquired.
+	 *
+	 * @param requestType
+	 * 	the RequestType for which the rate limiting shall be acquired (mainly for statistical purpose only)
+	 *
 	 * @return an empty Mono
 	 */
 	private Mono<Object> rateLimitingMono(RequestType requestType) {
 		return Mono.fromCallable(() -> {
-			
+
 			if (this.internalMetrics != null) {
 				this.internalMetrics.increaseRateLimitQueueSize();
 			}
-			
+
 			double waitTime = cfccRateLimiter.acquire(1);
-			
+
 			if (waitTime > 0.001) {
 				log.debug(String.format("Rate Limiting has throttled request of %s for %.3f seconds", requestType.getLoggerSuffix(), waitTime));
 			}
-			
+
 			if (this.internalMetrics != null) {
 				this.internalMetrics.decreaseRateLimitQueueSize();
 				this.internalMetrics.observeRateLimiterDuration(requestType.getMetricName(), waitTime);
 			}
-			
+
 			return new Object();
 		}).subscribeOn(Schedulers.boundedElastic())
-		.flatMap(x -> Mono.empty());
+				   .flatMap(x -> Mono.empty());
 	}
 
-	
+
 	/**
-	 * performs standard (raw) retrieval from the CF Cloud Controller of a single
-	 * page
-	 * 
+	 * performs standard (raw) retrieval from the CF Cloud Controller of a single page
+	 *
 	 * @param requestType
-	 *            the type information of the request which is being made
+	 * 	the type information of the request which is being made
 	 * @param key
-	 *            the key for which the request is being made (e.g. orgId,
-	 *            orgId|spaceName, ...)
+	 * 	the key for which the request is being made (e.g. orgId, orgId|spaceName, ...)
 	 * @param requestData
-	 *            an object which is being used as input parameter for the request
+	 * 	an object which is being used as input parameter for the request
 	 * @param requestFunction
-	 *            a function which calls the CF API operation, which is being made,
-	 *            <code>requestData</code> is used as input parameter for this
-	 *            function.
+	 * 	a function which calls the CF API operation, which is being made,
+	 * 	<code>requestData</code> is used as input parameter for this
+	 * 	function.
 	 * @param timeoutInMS
-	 *            the timeout value in milliseconds for a single data request to the
-	 *            CF Cloud Controller
+	 * 	the timeout value in milliseconds for a single data request to the CF Cloud Controller
+	 *
 	 * @return a Mono on the response provided by the CF Cloud Controller
 	 */
 	@SuppressWarnings("lgtm[java/sync-on-boxed-types]")
@@ -106,145 +107,214 @@ class ReactiveCFPaginatedRequestFetcher {
 	 * Moreover, the performance impact of the lock being engaged improperly is considered small,
 	 * as the duration of this method is assumed to be within milliseconds.
 	 * The effort of implementing a key to lock-object mapping (as alternative) is expected to be rather high
-	 * and would imply the risk of memory leaks. 
+	 * and would imply the risk of memory leaks.
 	 */
 	public <P, R> Mono<P> performGenericRetrieval(RequestType requestType, String key, R requestData,
-			Function<R, Mono<P>> requestFunction, int timeoutInMS) {
+												  Function<R, Mono<P>> requestFunction, int timeoutInMS) {
 		final String retrievalTypeName = requestType.getMetricName();
 		final String logName = requestType.getLoggerSuffix();
-		
-		final String lock = (this.getClass().getCanonicalName()+"|"+retrievalTypeName+"|"+key).intern();
-		
+
+		final String lock = (this.getClass().getCanonicalName() + "|" + retrievalTypeName + "|" + key).intern();
+
 		synchronized (lock) {
 			Mono<P> result = null;
 
 			ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, retrievalTypeName);
-			
+
 			final Mono<P> enrichedRequestFunction = requestFunction.apply(requestData)
-				.timeout(Duration.ofMillis(timeoutInMS));
+																   .timeout(Duration.ofMillis(timeoutInMS));
 			/*
-			 * Note 1: Applying (i.e. calling) the function "requestFunction" here  
-			 * does not trigger the request to be sent to the CFCC. 
+			 * Note 1: Applying (i.e. calling) the function "requestFunction" here
+			 * does not trigger the request to be sent to the CFCC.
 			 * Instead, it just will create the corresponding Flux/Mono, which does
-			 * not have any subscriber yet. 
-			 * 
+			 * not have any subscriber yet.
+			 *
 			 * Note 2: There is a major difference between the coding modeled
-			 * 
+			 *
 			 * requestFunction.apply(requestData).timeout(...)
-			 * 
+			 *
 			 * and
-			 * 
+			 *
 			 * someMono.flatMap(value -> requestFunction).timeout(...)
-			 * 
+			 *
 			 * The major point here is that the first variant applies the timeout
 			 * only to the stream returned by requestFunction.apply(...), whilst
 			 * the second variant applies it to
 			 * 1. someMono,
 			 * 2. the flatMap function
 			 * 3. the return value of the requestFunction
-			 * 
-			 * The difference there is that in the second variant counting 
+			 *
+			 * The difference there is that in the second variant counting
 			 * for the timeout starts already when someMono is subscribed to.
 			 * In the second variant, someMono is not considered.
-			 * 
+			 *
 			 * In this case here, the difference may be huge: The first variant
-			 * puts a timeout on each request (which is what we want). The 
+			 * puts a timeout on each request (which is what we want). The
 			 * second variant means that timeout would be counting from the
-			 * first subscription happening - which is wrong especially in case 
+			 * first subscription happening - which is wrong especially in case
 			 * of retry attempts.
 			 */
 
 			result = this.rateLimitingMono(requestType).then(Mono.just(reactiveTimer))
-					// start the timer
-					.flatMap(timer -> {
-						timer.start();
-						return Mono.just(0 /* any value will just do; will be ignored */); // Cannot use Mono.empty() here!
-					}).flatMap(nothing -> enrichedRequestFunction)
-					.retryWhen(Retry.backoff(2, this.initialBackoffDelay))
-					/*
-					 * Note: Don't push the retry attempts above into enrichedRequestFunction!
-					 * It would change the semantics of the metric behind the timer.
-					 * see also https://github.com/promregator/promregator/pull/174/files#r392031592
-					 */
-					.doOnError(throwable -> {
-						Throwable unwrappedThrowable = Exceptions.unwrap(throwable);
-						if (unwrappedThrowable instanceof TimeoutException) {
-							log.error(String.format(
-									"Async retrieval of %s with key %s caused a timeout after %dms even though we tried three times",
-									logName, key, timeoutInMS));
-						} else if (unwrappedThrowable instanceof OutOfMemoryError){
-							// This may be an direct memory or a heap error!
-							// Using String.format and/or log.error here is a bad idea - it takes memory!
-							
-							if (System.getenv("VCAP_APPLICATION") != null) {
-								// we assume that we are running on a Cloud Foundry container
-								this.triggerOutOfMemoryRestart();
-							}
-							
-						} else {
-							log.error(String.format("Async retrieval of %s with key %s raised a reactor error", logName,
-									key), unwrappedThrowable);
-						}
-					})
-					// stop the timer
-					.zipWith(Mono.just(reactiveTimer)).map(tuple -> {
-						tuple.getT2().stop();
-						return tuple.getT1();
-					}).log(log.getName() + "." + logName, Level.FINE).cache();
+						 // start the timer
+						 .flatMap(timer -> {
+							 timer.start();
+							 return Mono.just(0 /* any value will just do; will be ignored */); // Cannot use Mono.empty() here!
+						 }).flatMap(nothing -> enrichedRequestFunction)
+						 .retryWhen(Retry.backoff(2, this.initialBackoffDelay))
+						 /*
+						  * Note: Don't push the retry attempts above into enrichedRequestFunction!
+						  * It would change the semantics of the metric behind the timer.
+						  * see also https://github.com/promregator/promregator/pull/174/files#r392031592
+						  */
+						 .doOnError(throwable -> {
+							 Throwable unwrappedThrowable = Exceptions.unwrap(throwable);
+							 if (unwrappedThrowable instanceof TimeoutException) {
+								 log.error(String.format(
+									 "Async retrieval of %s with key %s caused a timeout after %dms even though we tried three times",
+									 logName, key, timeoutInMS));
+							 }
+							 else if (unwrappedThrowable instanceof OutOfMemoryError) {
+								 // This may be an direct memory or a heap error!
+								 // Using String.format and/or log.error here is a bad idea - it takes memory!
+
+								 if (System.getenv("VCAP_APPLICATION") != null) {
+									 // we assume that we are running on a Cloud Foundry container
+									 this.triggerOutOfMemoryRestart();
+								 }
+
+							 }
+							 else {
+								 log.error(String.format("Async retrieval of %s with key %s raised a reactor error", logName,
+														 key), unwrappedThrowable);
+							 }
+						 })
+						 // stop the timer
+						 .zipWith(Mono.just(reactiveTimer)).map(tuple -> {
+					tuple.getT2().stop();
+					return tuple.getT1();
+				}).log(log.getName() + "." + logName, Level.FINE).cache();
 
 			return result;
 		}
 	}
 
-	@SuppressFBWarnings(value = "DM_EXIT", justification="Restart of JVM is done intentionally here!")
+	@SuppressFBWarnings(value = "DM_EXIT", justification = "Restart of JVM is done intentionally here!")
 	private void triggerOutOfMemoryRestart() {
 		System.err.println("Out of Memory situation detected on talking to the Cloud Foundry Controller; restarting application");
 		System.exit(ExitCodes.CF_ACCESSOR_OUT_OF_MEMORY);
 	}
-	
+
 	/**
-	 * performs a retrieval from the CF Cloud Controller fetching all pages
-	 * available.
-	 * 
+	 * performs a retrieval from the CF Cloud Controller fetching all pages available.
+	 *
 	 * @param requestType
-	 *            the type information of the request which is being made
+	 * 	the type information of the request which is being made
 	 * @param key
-	 *            the key for which the request is being made (e.g. orgId,
-	 *            orgId|spaceName, ...)
+	 * 	the key for which the request is being made (e.g. orgId, orgId|spaceName, ...)
 	 * @param requestGenerator
-	 *            a request generator function, which permits creating request
-	 *            objects instance for a given set of page parameters (e.g. for
-	 *            which page, using which page size, ...)
+	 * 	a request generator function, which permits creating request objects instance for a given set of page parameters (e.g. for which page, using
+	 * 	which page size, ...)
 	 * @param requestFunction
-	 *            a function which calls the CF API operation, which is being made.
+	 * 	a function which calls the CF API operation, which is being made.
 	 * @param timeoutInMS
-	 *            the timeout value in milliseconds for a single data request to the
-	 *            CF Cloud Controller
+	 * 	the timeout value in milliseconds for a single data request to the CF Cloud Controller
 	 * @param responseGenerator
-	 *            a response generator function, which permits creating a response
-	 *            object, which contains the collected resources of all pages
-	 *            retrieved.
+	 * 	a response generator function, which permits creating a response object, which contains the collected resources of all pages retrieved.
+	 *
 	 * @return a Mono on the response provided by the CF Cloud Controller
 	 */
 	public <S, P extends PaginatedResponse<?>, R extends PaginatedRequest> Mono<P> performGenericPagedRetrieval(
-			RequestType requestType, String key, PaginatedRequestGeneratorFunction<R> requestGenerator,
-			Function<R, Mono<P>> requestFunction, int timeoutInMS,
-			PaginatedResponseGeneratorFunction<S, P> responseGenerator) {
+		RequestType requestType, String key, PaginatedRequestGeneratorFunction<R> requestGenerator,
+		Function<R, Mono<P>> requestFunction, int timeoutInMS,
+		PaginatedResponseGeneratorFunction<S, P> responseGenerator) {
 
 		final String pageRetrievalType = requestType.getMetricName() + "_singlePage";
 
 		ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, pageRetrievalType);
 
 		Mono<P> firstPage = Mono.just(reactiveTimer).doOnNext(ReactiveTimer::start).flatMap(dummy ->
-				this.performGenericRetrieval(requestType, key, requestGenerator.
-								apply(OrderDirection.ASCENDING, RESULTS_PER_PAGE, 1), requestFunction,	timeoutInMS));
+																								this.performGenericRetrieval(requestType, key, requestGenerator
+																									.
+																										apply(OrderDirection.ASCENDING, RESULTS_PER_PAGE, 1), requestFunction, timeoutInMS));
 
 		Flux<R> requestFlux = firstPage.map(page -> page.getTotalPages() - 1)
-				.flatMapMany(pagesCount -> Flux.range(2, pagesCount))
-				.map(pageNumber -> requestGenerator.apply(OrderDirection.ASCENDING, RESULTS_PER_PAGE, pageNumber));
+									   .flatMapMany(pagesCount -> Flux.range(2, pagesCount))
+									   .map(pageNumber -> requestGenerator.apply(OrderDirection.ASCENDING, RESULTS_PER_PAGE, pageNumber));
 
 		Mono<List<P>> subsequentPagesList = requestFlux.flatMap(req ->
-				this.performGenericRetrieval(requestType, key, req, requestFunction, timeoutInMS)).collectList();
+																	this.performGenericRetrieval(requestType, key, req, requestFunction, timeoutInMS))
+													   .collectList();
+
+		/*
+		 * Word on error handling: We can't judge here what will be the consequence, if
+		 * the first page could be retrieved properly, but retrieving some some later
+		 * page fails. The implication would depend on the consumer (whether incomplete
+		 * data was ok or not). So the safe answer here is to raise an error for the
+		 * entire request. That, however, is already in place with the error handling in
+		 * performGenericRetrieval: the stream is already in state "error" and thus will
+		 * not emit any item.
+		 */
+
+		return Mono.zip(firstPage, subsequentPagesList, Mono.just(reactiveTimer)).map(tuple -> {
+			P first = tuple.getT1();
+			List<P> subsequent = tuple.getT2();
+
+			List<S> ret = new LinkedList<>();
+
+			ret.addAll((List<? extends S>) first.getResources());
+			for (P listResponse : subsequent) {
+				ret.addAll((List<? extends S>) listResponse.getResources());
+			}
+
+			P retObject = responseGenerator.apply(ret, subsequent.size() + 1);
+
+			tuple.getT3().stop();
+
+			return retObject;
+		});
+	}
+
+	/**
+	 * performs a retrieval from the CF Cloud Controller fetching all pages available.
+	 *
+	 * @param requestType
+	 * 	the type information of the request which is being made
+	 * @param key
+	 * 	the key for which the request is being made (e.g. orgId, orgId|spaceName, ...)
+	 * @param requestGenerator
+	 * 	a request generator function, which permits creating request objects instance for a given set of page parameters (e.g. for which page, using
+	 * 	which page size, ...)
+	 * @param requestFunction
+	 * 	a function which calls the CF API operation, which is being made.
+	 * @param timeoutInMS
+	 * 	the timeout value in milliseconds for a single data request to the CF Cloud Controller
+	 * @param responseGenerator
+	 * 	a response generator function, which permits creating a response object, which contains the collected resources of all pages retrieved.
+	 *
+	 * @return a Mono on the response provided by the CF Cloud Controller
+	 */
+	public <S, P extends org.cloudfoundry.client.v3.PaginatedResponse<?>, R extends org.cloudfoundry.client.v3.PaginatedRequest> Mono<P> performGenericPagedRetrievalV3(
+		RequestType requestType, String key, PaginatedRequestGeneratorFunctionV3<R> requestGenerator,
+		Function<R, Mono<P>> requestFunction, int timeoutInMS,
+		PaginatedResponseGeneratorFunctionV3<S, P> responseGenerator) {
+
+		final String pageRetrievalType = requestType.getMetricName() + "_singlePage";
+
+		ReactiveTimer reactiveTimer = new ReactiveTimer(this.internalMetrics, pageRetrievalType);
+
+		Mono<P> firstPage = Mono.just(reactiveTimer).doOnNext(ReactiveTimer::start).flatMap(dummy ->
+																								this.performGenericRetrieval(requestType, key, requestGenerator
+																									.
+																										apply(RESULTS_PER_PAGE, 1), requestFunction, timeoutInMS));
+
+		Flux<R> requestFlux = firstPage.map(page -> page.getPagination().getTotalPages() - 1)
+									   .flatMapMany(pagesCount -> Flux.range(2, pagesCount))
+									   .map(pageNumber -> requestGenerator.apply(RESULTS_PER_PAGE, pageNumber));
+
+		Mono<List<P>> subsequentPagesList = requestFlux.flatMap(req ->
+																	this.performGenericRetrieval(requestType, key, req, requestFunction, timeoutInMS))
+													   .collectList();
 
 		/*
 		 * Word on error handling: We can't judge here what will be the consequence, if

--- a/src/main/java/org/cloudfoundry/promregator/cfaccessor/client/ReactorInfoV3.java
+++ b/src/main/java/org/cloudfoundry/promregator/cfaccessor/client/ReactorInfoV3.java
@@ -1,0 +1,26 @@
+package org.cloudfoundry.promregator.cfaccessor.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.cloudfoundry.reactor.ConnectionContext;
+import org.cloudfoundry.reactor.TokenProvider;
+import org.cloudfoundry.reactor.client.v3.AbstractClientV3Operations;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+/**
+ * Call the v3 info API and returns a JsonNode. Since we do not care about the actual response (other than errors), we do not need to
+ * model the whole response object.
+ * Issue: https://github.com/cloudfoundry/cf-java-client/issues/1097
+ */
+public class ReactorInfoV3 extends AbstractClientV3Operations {
+
+	public ReactorInfoV3(ConnectionContext connectionContext, Mono<String> root, TokenProvider tokenProvider, Map<String, String> requestTags) {
+		super(connectionContext, root, tokenProvider, requestTags);
+	}
+
+	public Mono<JsonNode> get() {
+		return get("", JsonNode.class, builder -> builder.pathSegment("info"))
+			.checkpoint();
+	}
+}

--- a/src/main/java/org/cloudfoundry/promregator/config/ConfigurationValidations.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/ConfigurationValidations.java
@@ -3,18 +3,15 @@ package org.cloudfoundry.promregator.config;
 import javax.annotation.PostConstruct;
 
 import org.cloudfoundry.promregator.config.validations.ConfigurationValidation;
-import org.cloudfoundry.promregator.config.validations.PreferredRouteRegexMustBeCompilable;
-import org.cloudfoundry.promregator.config.validations.TargetsHaveConsistentAuthenticatorId;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
 
 public class ConfigurationValidations {
 	@Autowired
 	private PromregatorConfiguration promregatorConfiguration;
-
-	protected ConfigurationValidation[] listOfValidations = {
-			new TargetsHaveConsistentAuthenticatorId(),
-			new PreferredRouteRegexMustBeCompilable()
-		};
+	@Autowired
+	protected List<ConfigurationValidation> listOfValidations;
 	
 	@PostConstruct
 	protected void validateConfiguration() {

--- a/src/main/java/org/cloudfoundry/promregator/config/Target.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/Target.java
@@ -28,6 +28,8 @@ public class Target {
 
 	private String path;
 
+	private Boolean kubernetesAnnotations = false;
+
 	private String protocol;
 
 	private String authenticatorId;
@@ -62,6 +64,9 @@ public class Target {
 		this.applicationName = source.applicationName;
 		this.applicationRegex = source.applicationRegex;
 		this.path = source.path;
+		if (source.kubernetesAnnotations != null)
+			this.kubernetesAnnotations = source.kubernetesAnnotations;
+
 		this.protocol = source.protocol;
 		this.authenticatorId = source.authenticatorId;
 		this.internalRoutePort = source.internalRoutePort;
@@ -131,6 +136,14 @@ public class Target {
 
 	public void setPath(String path) {
 		this.path = path;
+	}
+
+	public Boolean getKubernetesAnnotations() {
+		return kubernetesAnnotations;
+	}
+
+	public void setKubernetesAnnotations(Boolean kubernetesAnnotations) {
+		this.kubernetesAnnotations = kubernetesAnnotations != null ? kubernetesAnnotations : false;
 	}
 
 	public String getProtocol() {
@@ -223,6 +236,8 @@ public class Target {
 		builder.append(applicationRegex);
 		builder.append(", path=");
 		builder.append(path);
+		builder.append(", kubernetesAnnotations=");
+		builder.append(kubernetesAnnotations.toString());
 		builder.append(", protocol=");
 		builder.append(protocol);
 		builder.append(", authenticatorId=");

--- a/src/main/java/org/cloudfoundry/promregator/config/validations/CompatibleCAPIVersion.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/validations/CompatibleCAPIVersion.java
@@ -1,0 +1,23 @@
+package org.cloudfoundry.promregator.config.validations;
+
+import org.cloudfoundry.promregator.cfaccessor.CFAccessor;
+import org.cloudfoundry.promregator.config.PromregatorConfiguration;
+import org.cloudfoundry.promregator.config.Target;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CompatibleCAPIVersion implements ConfigurationValidation {
+	@Autowired
+	private CFAccessor cfAccessor;
+
+	private boolean usingV3OnlyFeature(Target targetConfiguration) {
+		return targetConfiguration.getKubernetesAnnotations();
+	}
+
+	@Override
+	public String validate(PromregatorConfiguration promregatorConfiguration) {
+		return promregatorConfiguration.getTargets().stream().anyMatch(this::usingV3OnlyFeature) &&
+			!cfAccessor.isV3Enabled() ? "You have enabled features which require V3 CAPI support" : null;
+	}
+}

--- a/src/main/java/org/cloudfoundry/promregator/config/validations/PreferredRouteRegexMustBeCompilable.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/validations/PreferredRouteRegexMustBeCompilable.java
@@ -6,10 +6,12 @@ import java.util.regex.PatternSyntaxException;
 
 import org.cloudfoundry.promregator.config.PromregatorConfiguration;
 import org.cloudfoundry.promregator.config.Target;
+import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Component
 public class PreferredRouteRegexMustBeCompilable implements ConfigurationValidation {
 	private static final Logger log = LoggerFactory.getLogger(PreferredRouteRegexMustBeCompilable.class);
 	

--- a/src/main/java/org/cloudfoundry/promregator/config/validations/TargetsHaveConsistentAuthenticatorId.java
+++ b/src/main/java/org/cloudfoundry/promregator/config/validations/TargetsHaveConsistentAuthenticatorId.java
@@ -7,12 +7,14 @@ import org.cloudfoundry.promregator.config.Target;
 import org.cloudfoundry.promregator.config.TargetAuthenticatorConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 /**
  * All targets must have an authenticatorId (if specified), which is specified
  * in the list of targetAuthenticators (referential integrity).
  *
  */
+@Component
 public class TargetsHaveConsistentAuthenticatorId implements ConfigurationValidation {
 	private static final Logger log = LoggerFactory.getLogger(TargetsHaveConsistentAuthenticatorId.class);
 

--- a/src/main/java/org/cloudfoundry/promregator/fetcher/CFMetricsFetcher.java
+++ b/src/main/java/org/cloudfoundry/promregator/fetcher/CFMetricsFetcher.java
@@ -52,7 +52,7 @@ public class CFMetricsFetcher implements MetricsFetcher {
 	
 	private AbstractMetricFamilySamplesEnricher mfse;
 
-	static final CloseableHttpClient httpclient = HttpClients.createDefault();
+	static final CloseableHttpClient httpclient = HttpClients.createSystem();
 
 	private MetricsFetcherMetrics mfm;
 

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ResolvedTarget.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ResolvedTarget.java
@@ -17,6 +17,8 @@ public class ResolvedTarget {
 	private String protocol;
 
 	private String applicationId;
+
+	private Boolean kubernetesAnnotations = false;
 	
 	public ResolvedTarget() {
 		super();
@@ -29,6 +31,7 @@ public class ResolvedTarget {
 		this.applicationName = configTarget.getApplicationName();
 		this.path = configTarget.getPath();
 		this.protocol = configTarget.getProtocol();
+		this.kubernetesAnnotations = configTarget.getKubernetesAnnotations();
 	}
 	
 	public String getOrgName() {
@@ -64,6 +67,14 @@ public class ResolvedTarget {
 
 	public void setPath(String path) {
 		this.path = path;
+	}
+
+	public Boolean getKubernetesAnnotations() {
+		return kubernetesAnnotations;
+	}
+
+	public void setKubernetesAnnotations(Boolean kubernetesAnnotations) {
+		this.kubernetesAnnotations = kubernetesAnnotations != null ? kubernetesAnnotations : false;
 	}
 
 	public String getProtocol() {
@@ -107,6 +118,7 @@ public class ResolvedTarget {
 		result = prime * result + ((applicationName == null) ? 0 : applicationName.hashCode());
 		result = prime * result + ((orgName == null) ? 0 : orgName.hashCode());
 		result = prime * result + ((path == null) ? 0 : path.hashCode());
+		result = prime * result + ((kubernetesAnnotations == null) ? 0 : kubernetesAnnotations.hashCode());
 		result = prime * result + ((protocol == null) ? 0 : protocol.hashCode());
 		result = prime * result + ((spaceName == null) ? 0 : spaceName.hashCode());
 		result = prime * result + ((applicationId == null) ? 0 : applicationId.hashCode());
@@ -156,6 +168,13 @@ public class ResolvedTarget {
 		} else if (!path.equals(other.path)) {
 			return false;
 		}
+		if (kubernetesAnnotations == null) {
+			if (other.kubernetesAnnotations != null) {
+				return false;
+			}
+		} else if (!kubernetesAnnotations.equals(other.kubernetesAnnotations)) {
+			return false;
+		}
 		if (protocol == null) {
 			if (other.protocol != null) {
 				return false;
@@ -189,6 +208,8 @@ public class ResolvedTarget {
 		builder.append(applicationId);
 		builder.append(", path=");
 		builder.append(path);
+		builder.append(", kuberntesAnnotations=");
+		builder.append(kubernetesAnnotations.toString());
 		builder.append(", protocol=");
 		builder.append(protocol);
 		builder.append("]");

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
@@ -87,7 +87,7 @@ public class CFAccessorCacheCaffeineSpringApplication {
 		}
 
 		@Override
-		public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
 			return Mono.just(org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder().build());
 		}
 

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
@@ -6,6 +6,8 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -62,7 +64,47 @@ public class CFAccessorCacheCaffeineSpringApplication {
 		@Override
 		public Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId) {
 			return Mono.just(ListOrganizationDomainsResponse.builder().build());
-		}		
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+			return Mono.just(org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder().build());
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+			return Mono.just(org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder().build());
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+			return Mono.just(org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder().build());
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+			return Mono.just(org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder().build());
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+			return Mono.just(org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder().build());
+		}
+
+		@Override
+		public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+			return Mono.just(GetSpaceResponse.builder().id(spaceId).name("dummy").createdAt("time").build());
+		}
+
+		@Override
+		public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+			return Mono.just(org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse.builder().build());
+		}
+
+		@Override
+		public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+			return Mono.just(ListApplicationRoutesResponse.builder().build());
+		}
 
 		@Override
 		public void reset() {

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineSpringApplication.java
@@ -107,6 +107,11 @@ public class CFAccessorCacheCaffeineSpringApplication {
 		}
 
 		@Override
+		public boolean isV3Enabled() {
+			return true;
+		}
+
+		@Override
 		public void reset() {
 			// nothing to be done
 		}		

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineTest.java
@@ -130,11 +130,11 @@ class CFAccessorCacheCaffeineTest {
 
 	@Test
 	void testRetrieveAllApplicationIdsInSpaceV3() {
-		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
-		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		subject.retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
 
-		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
-		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		subject.retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
 	}
 
 	@Test

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheCaffeineTest.java
@@ -4,6 +4,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.JUnitTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,4 +105,61 @@ class CFAccessorCacheCaffeineTest {
 		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllDomains("dummy");
 	}
 
+	@Test
+	void testRetrieveOrgIdV3() throws InterruptedException {
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> response1 = subject.retrieveOrgIdV3("dummy");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveOrgIdV3("dummy");
+
+		Thread.sleep(10);
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> response2 = subject.retrieveOrgIdV3("dummy");
+		assertThat(response1.block()).isEqualTo(response2.block());
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveOrgIdV3("dummy");
+	}
+
+	@Test
+	void testRetrieveSpaceIdV3() {
+
+		Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> response1 = subject.retrieveSpaceIdV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveSpaceIdV3("dummy1", "dummy2");
+
+		Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> response2 = subject.retrieveSpaceIdV3("dummy1", "dummy2");
+		assertThat(response1.block()).isEqualTo(response2.block());
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveSpaceIdV3("dummy1", "dummy2");
+	}
+
+	@Test
+	void testRetrieveAllApplicationIdsInSpaceV3() {
+		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+
+		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+	}
+
+	@Test
+	void testRetrieveAllOrgIdsV3() {
+		subject.retrieveAllOrgIdsV3();
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllOrgIdsV3();
+	}
+
+	@Test
+	void testRetrieveSpaceSummaryV3() {
+		Mono<GetSpaceResponse> response1 = subject.retrieveSpaceV3("dummy");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveSpaceV3("dummy");
+
+		Mono<GetSpaceResponse> response2 = subject.retrieveSpaceV3("dummy");
+		assertThat(response1.block()).isEqualTo(response2.block());
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveSpaceV3("dummy");
+	}
+
+	@Test
+	void testRetrieveDomainV3() {
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> response1 = subject.retrieveAllDomainsV3("dummy");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllDomainsV3("dummy");
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> response2 = subject.retrieveAllDomainsV3("dummy");
+		assertThat(response1.block()).isEqualTo(response2.block());
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllDomainsV3("dummy");
+	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicSpringApplication.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicSpringApplication.java
@@ -24,6 +24,7 @@ public class CFAccessorCacheClassicSpringApplication {
 		Mockito.when(mock.retrieveAllApplicationIdsInSpace("dummy1", "dummy2")).thenReturn(Mockito.mock(Mono.class));
 		Mockito.when(mock.retrieveSpaceSummary("dummy")).thenReturn(Mockito.mock(Mono.class));
 		Mockito.when(mock.retrieveAllDomains("dummy")).thenReturn(Mockito.mock(Mono.class));
+		Mockito.when(mock.retrieveAllApplicationsInSpaceV3("dummy1", "dummy2")).thenReturn(Mockito.mock(Mono.class));
 		return mock;
 	}
 	

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicTest.java
@@ -114,12 +114,11 @@ class CFAccessorCacheClassicTest {
 
 	@Test
 	void testRetrieveAllApplicationIdsInSpaceV3() {
-		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
-		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		subject.retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
 
-		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
-		// Cache not implemented
-		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		subject.retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationsInSpaceV3("dummy1", "dummy2");
 	}
 
 	@Test

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicTest.java
@@ -4,6 +4,7 @@ import org.cloudfoundry.client.v2.organizations.ListOrganizationDomainsResponse;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.spaces.GetSpaceSummaryResponse;
 import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.cloudfoundry.promregator.JUnitTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,6 +92,57 @@ class CFAccessorCacheClassicTest {
 		Mono<ListOrganizationDomainsResponse> response2 = subject.retrieveAllDomains("dummy");
 		assertThat(response1).isEqualTo(response2);
 		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllDomains("dummy");
+	}
+
+	@Test
+	void testRetrieveDomainsV3() {
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> response1 = subject.retrieveAllDomainsV3("dummy");
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> response2 = subject.retrieveAllDomainsV3("dummy");
+		assertThat(response1).isEqualTo(response2);
+		// Cache not implemented
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllDomainsV3("dummy");
+	}
+
+	@Test
+	void testRetrieveSpaceSummaryV3() {
+		Mono<GetSpaceResponse> response1 = subject.retrieveSpaceV3("dummy");
+		Mono<GetSpaceResponse> response2 = subject.retrieveSpaceV3("dummy");
+		assertThat(response1).isEqualTo(response2);
+		// Cache not implemented
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveSpaceV3("dummy");
+	}
+
+	@Test
+	void testRetrieveAllApplicationIdsInSpaceV3() {
+		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+
+		subject.retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+		// Cache not implemented
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveAllApplicationIdsInSpaceV3("dummy1", "dummy2");
+	}
+
+	@Test
+	void testRetrieveOrgIdV3() {
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> response1 = subject.retrieveOrgIdV3("dummy");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveOrgIdV3("dummy");
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> response2 = subject.retrieveOrgIdV3("dummy");
+		assertThat(response1).isEqualTo(response2);
+		// Cache not implemented
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveOrgIdV3("dummy");
+	}
+
+	@Test
+	void testRetrieveSpaceIdV3() {
+
+		Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> response1 = subject.retrieveSpaceIdV3("dummy1", "dummy2");
+		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveSpaceIdV3("dummy1", "dummy2");
+
+		Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> response2 = subject.retrieveSpaceIdV3("dummy1", "dummy2");
+		assertThat(response1).isEqualTo(response2);
+		// Cache not implemented
+		Mockito.verify(this.parentMock, Mockito.times(2)).retrieveSpaceIdV3("dummy1" ,"dummy2");
 	}
 
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorCacheClassicTest.java
@@ -59,7 +59,6 @@ class CFAccessorCacheClassicTest {
 
 	@Test
 	void testRetrieveSpaceId() {
-		
 		Mono<ListSpacesResponse> response1 = subject.retrieveSpaceId("dummy1", "dummy2");
 		Mockito.verify(this.parentMock, Mockito.times(1)).retrieveSpaceId("dummy1", "dummy2");
 		

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
@@ -219,7 +219,7 @@ public class CFAccessorMassMock implements CFAccessor {
 	}
 
 	@Override
-	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
@@ -25,6 +25,8 @@ import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.domains.Domain;
 import org.cloudfoundry.client.v2.domains.DomainEntity;
 import org.cloudfoundry.client.v2.domains.DomainResource;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.junit.jupiter.api.Assertions;
 
 import reactor.core.publisher.Mono;
@@ -194,5 +196,45 @@ public class CFAccessorMassMock implements CFAccessor {
 
 		ListOrganizationDomainsResponse response = ListOrganizationDomainsResponse.builder().addAllResources(domains).build();
 		return Mono.just(response);
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMassMock.java
@@ -237,4 +237,9 @@ public class CFAccessorMassMock implements CFAccessor {
 	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
 		throw new UnsupportedOperationException();
 	}
+
+	@Override
+	public boolean isV3Enabled() {
+		return true;
+	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
@@ -23,6 +23,10 @@ import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.domains.Domain;
 import org.cloudfoundry.client.v2.domains.DomainEntity;
 import org.cloudfoundry.client.v2.domains.DomainResource;
+import org.cloudfoundry.client.v3.BuildpackData;
+import org.cloudfoundry.client.v3.Lifecycle;
+import org.cloudfoundry.client.v3.LifecycleData;
+import org.cloudfoundry.client.v3.LifecycleType;
 import org.cloudfoundry.client.v3.applications.ApplicationState;
 import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
 import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
@@ -396,7 +400,7 @@ public class CFAccessorMock implements CFAccessor {
 	}
 
 	@Override
-	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationsInSpaceV3(String orgId, String spaceId) {
 		if (orgId.equals(UNITTEST_ORG_UUID) && spaceId.equals(UNITTEST_SPACE_UUID)) {
 			List<org.cloudfoundry.client.v3.applications.ApplicationResource> list = new LinkedList<>();
 
@@ -405,18 +409,24 @@ public class CFAccessorMock implements CFAccessor {
 																																		.state(ApplicationState.STARTED)
 																																		.createdAt(CREATED_AT_TIMESTAMP)
 																																		.id(UNITTEST_APP1_UUID)
+																																		.lifecycle(Lifecycle.builder().data(BuildpackData.builder().build()).type(LifecycleType.BUILDPACK).build())
+																																		.metadata(org.cloudfoundry.client.v3.Metadata.builder().annotation("prometheus.io/scrape", "true").build())
 																																		.build();
 			list.add(ar);
 
 			ar = org.cloudfoundry.client.v3.applications.ApplicationResource.builder()
 																			.name("testapp2").state(ApplicationState.STARTED)
 																			.createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP2_UUID)
+																			.lifecycle(Lifecycle.builder().data(BuildpackData.builder().build()).type(LifecycleType.BUILDPACK).build())
+																			.metadata(org.cloudfoundry.client.v3.Metadata.builder().annotation("prometheus.io/scrape", "badValue").build())
 																			.build();
 			list.add(ar);
 
 			ar = org.cloudfoundry.client.v3.applications.ApplicationResource.builder()
 																			.name("internalapp").state(ApplicationState.STARTED)
 																			.createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP_INTERNAL_UUID)
+																			.lifecycle(Lifecycle.builder().data(BuildpackData.builder().build()).type(LifecycleType.BUILDPACK).build())
+																			.metadata(org.cloudfoundry.client.v3.Metadata.builder().annotation("prometheus.io/scrape", "true").annotation("prometheus.io/path", "/actuator/prometheus").build())
 																			.build();
 			list.add(ar);
 

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
@@ -23,6 +23,9 @@ import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.domains.Domain;
 import org.cloudfoundry.client.v2.domains.DomainEntity;
 import org.cloudfoundry.client.v2.domains.DomainResource;
+import org.cloudfoundry.client.v3.applications.ApplicationState;
+import org.cloudfoundry.client.v3.applications.ListApplicationRoutesResponse;
+import org.cloudfoundry.client.v3.spaces.GetSpaceResponse;
 import org.junit.jupiter.api.Assertions;
 
 import reactor.core.publisher.Mono;
@@ -42,7 +45,7 @@ public class CFAccessorMock implements CFAccessor {
 	public static final String UNITTEST_SHARED_DOMAIN_UUID = "be9b8696-2fa6-11e8-b467-0ed5f89f718b";
 	public static final String UNITTEST_SHARED_DOMAIN = "shared.domain.example.org";
 	public static final String UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID = "48ae5bb3-a625-4c16-9e30-e9a6b10ca1be";
-	public static final String UNITTEST_ADDITIONAL_SHARED_DOMAIN = "additionalSubdomain.shared.domain.example.org";	
+	public static final String UNITTEST_ADDITIONAL_SHARED_DOMAIN = "additionalSubdomain.shared.domain.example.org";
 
 	public static final String UNITTEST_INTERNAL_DOMAIN_UUID = "49225c7e-b4c3-45b2-b796-7bb9c64dc79d";
 	public static final String UNITTEST_INTERNAL_DOMAIN = "apps.internal";
@@ -52,7 +55,7 @@ public class CFAccessorMock implements CFAccessor {
 	public static final String UNITTEST_APP_INTERNAL_HOST = "internal-app";
 
 	public static final String CREATED_AT_TIMESTAMP = "2014-11-24T19:32:49+00:00";
-	public static final String UPDATED_AT_TIMESTAMP = "2014-11-24T19:32:49+00:00";	
+	public static final String UPDATED_AT_TIMESTAMP = "2014-11-24T19:32:49+00:00";
 
 	@Override
 	public Mono<ListOrganizationsResponse> retrieveOrgId(String orgName) {
@@ -60,26 +63,28 @@ public class CFAccessorMock implements CFAccessor {
 		if ("unittestorg".equalsIgnoreCase(orgName)) {
 
 			OrganizationResource or = OrganizationResource.builder()
-					.entity(OrganizationEntity.builder().name("unittestorg").build())
-					.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_ORG_UUID).build()
-					// Note that UpdatedAt is not set here, as this can also happen in real life!
-					).build();
+														  .entity(OrganizationEntity.builder().name("unittestorg").build())
+														  .metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_ORG_UUID).build()
+																	// Note that UpdatedAt is not set here, as this can also happen in real life!
+														  ).build();
 
 			List<org.cloudfoundry.client.v2.organizations.OrganizationResource> list = new LinkedList<>();
 			list.add(or);
 
 			ListOrganizationsResponse resp = org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse
-					.builder().addAllResources(list).build();
+				.builder().addAllResources(list).build();
 
 			return Mono.just(resp);
-		} else if ("doesnotexist".equals(orgName)) {
+		}
+		else if ("doesnotexist".equals(orgName)) {
 			return Mono.just(org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse.builder()
-					.resources(new ArrayList<>()).build());
-		} else if ("exception".equals(orgName)) {
+																							   .resources(new ArrayList<>()).build());
+		}
+		else if ("exception".equals(orgName)) {
 			return Mono.just(org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse.builder().build())
-					.map(x -> {
-						throw new Error("exception org name provided");
-					});
+					   .map(x -> {
+						   throw new Error("exception org name provided");
+					   });
 		}
 		Assertions.fail("Invalid OrgId request");
 		return null;
@@ -90,33 +95,37 @@ public class CFAccessorMock implements CFAccessor {
 		if (orgId.equals(UNITTEST_ORG_UUID)) {
 			if ("unittestspace".equalsIgnoreCase(spaceName)) {
 				SpaceResource sr = SpaceResource.builder().entity(SpaceEntity.builder().name("unittestspace").build())
-						.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_SPACE_UUID).build())
-						.build();
+												.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_SPACE_UUID).build())
+												.build();
 				List<SpaceResource> list = new LinkedList<>();
 				list.add(sr);
 				ListSpacesResponse resp = ListSpacesResponse.builder().addAllResources(list).build();
 				return Mono.just(resp);
-			} else if ("unittestspace-summarydoesnotexist".equals(spaceName)) {
+			}
+			else if ("unittestspace-summarydoesnotexist".equals(spaceName)) {
 				SpaceResource sr = SpaceResource.builder().entity(SpaceEntity.builder().name(spaceName).build())
-						.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP)
-								.id(UNITTEST_SPACE_UUID_DOESNOTEXIST).build())
-						.build();
+												.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP)
+																  .id(UNITTEST_SPACE_UUID_DOESNOTEXIST).build())
+												.build();
 				List<SpaceResource> list = new LinkedList<>();
 				list.add(sr);
 				ListSpacesResponse resp = ListSpacesResponse.builder().addAllResources(list).build();
 				return Mono.just(resp);
-			} else if ("unittestspace-summaryexception".equals(spaceName)) {
+			}
+			else if ("unittestspace-summaryexception".equals(spaceName)) {
 				SpaceResource sr = SpaceResource.builder().entity(SpaceEntity.builder().name(spaceName).build())
-						.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_SPACE_UUID_EXCEPTION)
-								.build())
-						.build();
+												.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_SPACE_UUID_EXCEPTION)
+																  .build())
+												.build();
 				List<SpaceResource> list = new LinkedList<>();
 				list.add(sr);
 				ListSpacesResponse resp = ListSpacesResponse.builder().addAllResources(list).build();
 				return Mono.just(resp);
-			} else if ("doesnotexist".equals(spaceName)) {
+			}
+			else if ("doesnotexist".equals(spaceName)) {
 				return Mono.just(ListSpacesResponse.builder().resources(new ArrayList<>()).build());
-			} else if ("exception".equals(spaceName)) {
+			}
+			else if ("exception".equals(spaceName)) {
 				return Mono.just(ListSpacesResponse.builder().build()).map(x -> {
 					throw new Error("exception space name provided");
 				});
@@ -133,28 +142,30 @@ public class CFAccessorMock implements CFAccessor {
 			List<ApplicationResource> list = new LinkedList<>();
 
 			ApplicationResource ar = ApplicationResource.builder()
-					.entity(ApplicationEntity.builder().name("testapp").state("STARTED").build())
-					.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP1_UUID).build())
-					.build();
+														.entity(ApplicationEntity.builder().name("testapp").state("STARTED").build())
+														.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP1_UUID).build())
+														.build();
 			list.add(ar);
 
 			ar = ApplicationResource.builder()
-					.entity(ApplicationEntity.builder().name("testapp2").state("STARTED").build())
-					.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP2_UUID).build())
-					.build();
+									.entity(ApplicationEntity.builder().name("testapp2").state("STARTED").build())
+									.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP2_UUID).build())
+									.build();
 			list.add(ar);
 
 			ar = ApplicationResource.builder()
-					.entity(ApplicationEntity.builder().name("internalapp").state("STARTED").build())
-					.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP_INTERNAL_UUID).build())
-					.build();
+									.entity(ApplicationEntity.builder().name("internalapp").state("STARTED").build())
+									.metadata(Metadata.builder().createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP_INTERNAL_UUID).build())
+									.build();
 			list.add(ar);
 
 			ListApplicationsResponse resp = ListApplicationsResponse.builder().addAllResources(list).build();
 			return Mono.just(resp);
-		} else if (UNITTEST_SPACE_UUID_DOESNOTEXIST.equals(spaceId)) {
+		}
+		else if (UNITTEST_SPACE_UUID_DOESNOTEXIST.equals(spaceId)) {
 			return Mono.just(ListApplicationsResponse.builder().build());
-		} else if (UNITTEST_SPACE_UUID_EXCEPTION.equals(spaceId)) {
+		}
+		else if (UNITTEST_SPACE_UUID_EXCEPTION.equals(spaceId)) {
 			return Mono.just(ListApplicationsResponse.builder().build()).map(x -> {
 				throw new Error("exception on AllAppIdsInSpace");
 			});
@@ -170,47 +181,50 @@ public class CFAccessorMock implements CFAccessor {
 			List<SpaceApplicationSummary> list = new LinkedList<>();
 
 			Domain sharedDomain = Domain.builder().id(UNITTEST_SHARED_DOMAIN_UUID).name(UNITTEST_SHARED_DOMAIN).build();
-			Domain additionalSharedDomain = Domain.builder().id(UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID).name(UNITTEST_ADDITIONAL_SHARED_DOMAIN).build();
+			Domain additionalSharedDomain = Domain.builder().id(UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID).name(UNITTEST_ADDITIONAL_SHARED_DOMAIN)
+												  .build();
 			Domain internalDomain = Domain.builder().id(UNITTEST_INTERNAL_DOMAIN_UUID).name(UNITTEST_INTERNAL_DOMAIN).build();
 
-			final String[] urls1 = { UNITTEST_APP1_HOST + "." + UNITTEST_SHARED_DOMAIN };
-			final Route[] routes1 = { Route.builder().domain(sharedDomain).host(UNITTEST_APP1_HOST).build() };
+			final String[] urls1 = {UNITTEST_APP1_HOST + "." + UNITTEST_SHARED_DOMAIN};
+			final Route[] routes1 = {Route.builder().domain(sharedDomain).host(UNITTEST_APP1_HOST).build()};
 			SpaceApplicationSummary sas = SpaceApplicationSummary.builder()
-					.id(UNITTEST_APP1_UUID)
-					.name("testapp")
-					.addAllRoutes(Arrays.asList(routes1))
-					.addAllUrls(Arrays.asList(urls1)).instances(2).build();
+																 .id(UNITTEST_APP1_UUID)
+																 .name("testapp")
+																 .addAllRoutes(Arrays.asList(routes1))
+																 .addAllUrls(Arrays.asList(urls1)).instances(2).build();
 			list.add(sas);
 
 			String additionalPath = "/additionalPath";
 
-			final String[] urls2 = { UNITTEST_APP2_HOST + "." + UNITTEST_SHARED_DOMAIN + additionalPath,
-					UNITTEST_APP2_HOST + "." + UNITTEST_ADDITIONAL_SHARED_DOMAIN + additionalPath };
-			final Route[] routes2 = { 
-					Route.builder().domain(sharedDomain).host(UNITTEST_APP2_HOST).path(additionalPath).build(),		
-					Route.builder().domain(additionalSharedDomain).host(UNITTEST_APP2_HOST).path(additionalPath).build() };
+			final String[] urls2 = {UNITTEST_APP2_HOST + "." + UNITTEST_SHARED_DOMAIN + additionalPath,
+				UNITTEST_APP2_HOST + "." + UNITTEST_ADDITIONAL_SHARED_DOMAIN + additionalPath};
+			final Route[] routes2 = {
+				Route.builder().domain(sharedDomain).host(UNITTEST_APP2_HOST).path(additionalPath).build(),
+				Route.builder().domain(additionalSharedDomain).host(UNITTEST_APP2_HOST).path(additionalPath).build()};
 			sas = SpaceApplicationSummary.builder()
-					.id(UNITTEST_APP2_UUID)
-					.name("testapp2")
-					.addAllRoutes(Arrays.asList(routes2))
-					.addAllUrls(Arrays.asList(urls2)).instances(1).build();
+										 .id(UNITTEST_APP2_UUID)
+										 .name("testapp2")
+										 .addAllRoutes(Arrays.asList(routes2))
+										 .addAllUrls(Arrays.asList(urls2)).instances(1).build();
 			list.add(sas);
 
-			final String[] urls3 = { UNITTEST_APP_INTERNAL_HOST + "." + UNITTEST_INTERNAL_DOMAIN };
-			final Route[] routes3 = { Route.builder().domain(internalDomain).host(UNITTEST_APP_INTERNAL_HOST).build() };
+			final String[] urls3 = {UNITTEST_APP_INTERNAL_HOST + "." + UNITTEST_INTERNAL_DOMAIN};
+			final Route[] routes3 = {Route.builder().domain(internalDomain).host(UNITTEST_APP_INTERNAL_HOST).build()};
 			sas = SpaceApplicationSummary.builder()
-					.id(UNITTEST_APP_INTERNAL_UUID)
-					.name("internalapp")
-					.addAllRoutes(Arrays.asList(routes3))
-					.addAllUrls(Arrays.asList(urls3)).instances(2).build();
+										 .id(UNITTEST_APP_INTERNAL_UUID)
+										 .name("internalapp")
+										 .addAllRoutes(Arrays.asList(routes3))
+										 .addAllUrls(Arrays.asList(urls3)).instances(2).build();
 			list.add(sas);
 
 			GetSpaceSummaryResponse resp = GetSpaceSummaryResponse.builder().addAllApplications(list).build();
 
 			return Mono.just(resp);
-		} else if (spaceId.equals(UNITTEST_SPACE_UUID_DOESNOTEXIST)) {
+		}
+		else if (spaceId.equals(UNITTEST_SPACE_UUID_DOESNOTEXIST)) {
 			return Mono.just(GetSpaceSummaryResponse.builder().build());
-		} else if (spaceId.equals(UNITTEST_SPACE_UUID_EXCEPTION)) {
+		}
+		else if (spaceId.equals(UNITTEST_SPACE_UUID_EXCEPTION)) {
 			return Mono.just(GetSpaceSummaryResponse.builder().build()).map(x -> {
 				throw new Error("exception on application summary");
 			});
@@ -232,7 +246,7 @@ public class CFAccessorMock implements CFAccessor {
 	@Override
 	public Mono<GetInfoResponse> getInfo() {
 		GetInfoResponse data = GetInfoResponse.builder().description("CFAccessorMock").name("CFAccessorMock").version(1)
-				.build();
+											  .build();
 
 		return Mono.just(data);
 	}
@@ -243,46 +257,230 @@ public class CFAccessorMock implements CFAccessor {
 	}
 
 	@Override
-	public Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId) {		
+	public Mono<ListOrganizationDomainsResponse> retrieveAllDomains(String orgId) {
 		List<DomainResource> domains = new ArrayList<DomainResource>();
 		DomainResource domain = DomainResource.builder()
-				.entity(
-					DomainEntity.builder()
-					.name(UNITTEST_INTERNAL_DOMAIN)
-					.internal(true)
-					.build())
-				.metadata(
-					Metadata.builder().id(UNITTEST_INTERNAL_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())    
-				.build();
+											  .entity(
+												  DomainEntity.builder()
+															  .name(UNITTEST_INTERNAL_DOMAIN)
+															  .internal(true)
+															  .build())
+											  .metadata(
+												  Metadata.builder().id(UNITTEST_INTERNAL_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())
+											  .build();
 
 		domains.add(domain);
 
 		domain = DomainResource.builder()
-				.entity(
-					DomainEntity.builder()
-					.name(UNITTEST_SHARED_DOMAIN)
-					.internal(false)
-					.build())
-				.metadata(
-					Metadata.builder().id(UNITTEST_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())    
-				.build();
+							   .entity(
+								   DomainEntity.builder()
+											   .name(UNITTEST_SHARED_DOMAIN)
+											   .internal(false)
+											   .build())
+							   .metadata(
+								   Metadata.builder().id(UNITTEST_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())
+							   .build();
 
 		domains.add(domain);
 
 		domain = DomainResource.builder()
-				.entity(
-					DomainEntity.builder()
-					.name(UNITTEST_ADDITIONAL_SHARED_DOMAIN)
-					.internal(false)
-					.build())
-				.metadata(
-					Metadata.builder().id(UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())    
-				.build();
+							   .entity(
+								   DomainEntity.builder()
+											   .name(UNITTEST_ADDITIONAL_SHARED_DOMAIN)
+											   .internal(false)
+											   .build())
+							   .metadata(
+								   Metadata.builder().id(UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP).build())
+							   .build();
 
 		domains.add(domain);
 
 		ListOrganizationDomainsResponse response = ListOrganizationDomainsResponse.builder().addAllResources(domains).build();
 		return Mono.just(response);
 	}
-	
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveOrgIdV3(String orgName) {
+		if ("unittestorg".equalsIgnoreCase(orgName)) {
+
+			org.cloudfoundry.client.v3.organizations.OrganizationResource or = org.cloudfoundry.client.v3.organizations.OrganizationResource.builder()
+																																			.name("unittestorg")
+																																			.createdAt(CREATED_AT_TIMESTAMP)
+																																			.id(UNITTEST_ORG_UUID)
+																																			// Note that UpdatedAt is not set here, as this can also happen in real life!
+																																			.build();
+
+			List<org.cloudfoundry.client.v3.organizations.OrganizationResource> list = new LinkedList<>();
+			list.add(or);
+
+			org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse resp = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse
+				.builder().addAllResources(list).build();
+
+			return Mono.just(resp);
+		}
+		else if ("doesnotexist".equals(orgName)) {
+			return Mono.just(org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder()
+																							   .resources(new ArrayList<>()).build());
+		}
+		else if ("exception".equals(orgName)) {
+			return Mono.just(org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder().build())
+					   .map(x -> {
+						   throw new Error("exception org name provided");
+					   });
+		}
+		Assertions.fail("Invalid OrgId request");
+		return null;
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> retrieveAllOrgIdsV3() {
+		return this.retrieveOrgIdV3("unittestorg");
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdV3(String orgId, String spaceName) {
+		if (orgId.equals(UNITTEST_ORG_UUID)) {
+			if ("unittestspace".equalsIgnoreCase(spaceName)) {
+				org.cloudfoundry.client.v3.spaces.SpaceResource sr = org.cloudfoundry.client.v3.spaces.SpaceResource.builder().name("unittestspace")
+																													.createdAt(CREATED_AT_TIMESTAMP)
+																													.id(UNITTEST_SPACE_UUID)
+																													.build();
+				List<org.cloudfoundry.client.v3.spaces.SpaceResource> list = new LinkedList<>();
+				list.add(sr);
+				org.cloudfoundry.client.v3.spaces.ListSpacesResponse resp = org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder()
+																																.addAllResources(list)
+																																.build();
+				return Mono.just(resp);
+			}
+			else if ("unittestspace-summarydoesnotexist".equals(spaceName)) {
+				org.cloudfoundry.client.v3.spaces.SpaceResource sr = org.cloudfoundry.client.v3.spaces.SpaceResource.builder().name(spaceName)
+																													.createdAt(CREATED_AT_TIMESTAMP)
+																													.id(UNITTEST_SPACE_UUID_DOESNOTEXIST)
+																													.build();
+				List<org.cloudfoundry.client.v3.spaces.SpaceResource> list = new LinkedList<>();
+				list.add(sr);
+				org.cloudfoundry.client.v3.spaces.ListSpacesResponse resp = org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder()
+																																.addAllResources(list)
+																																.build();
+				return Mono.just(resp);
+			}
+			else if ("unittestspace-summaryexception".equals(spaceName)) {
+				org.cloudfoundry.client.v3.spaces.SpaceResource sr = org.cloudfoundry.client.v3.spaces.SpaceResource.builder().name(spaceName)
+																													.createdAt(CREATED_AT_TIMESTAMP)
+																													.id(UNITTEST_SPACE_UUID_EXCEPTION)
+																													.build();
+				List<org.cloudfoundry.client.v3.spaces.SpaceResource> list = new LinkedList<>();
+				list.add(sr);
+				org.cloudfoundry.client.v3.spaces.ListSpacesResponse resp = org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder()
+																																.addAllResources(list)
+																																.build();
+				return Mono.just(resp);
+			}
+			else if ("doesnotexist".equals(spaceName)) {
+				return Mono.just(org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder().resources(new ArrayList<>()).build());
+			}
+			else if ("exception".equals(spaceName)) {
+				return Mono.just(org.cloudfoundry.client.v3.spaces.ListSpacesResponse.builder().build()).map(x -> {
+					throw new Error("exception space name provided");
+				});
+			}
+		}
+
+		Assertions.fail("Invalid SpaceId request");
+		return null;
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.spaces.ListSpacesResponse> retrieveSpaceIdsInOrgV3(String orgId) {
+		return this.retrieveSpaceIdV3(UNITTEST_ORG_UUID, "unittestspace");
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.applications.ListApplicationsResponse> retrieveAllApplicationIdsInSpaceV3(String orgId, String spaceId) {
+		if (orgId.equals(UNITTEST_ORG_UUID) && spaceId.equals(UNITTEST_SPACE_UUID)) {
+			List<org.cloudfoundry.client.v3.applications.ApplicationResource> list = new LinkedList<>();
+
+			org.cloudfoundry.client.v3.applications.ApplicationResource ar = org.cloudfoundry.client.v3.applications.ApplicationResource.builder()
+																																		.name("testapp")
+																																		.state(ApplicationState.STARTED)
+																																		.createdAt(CREATED_AT_TIMESTAMP)
+																																		.id(UNITTEST_APP1_UUID)
+																																		.build();
+			list.add(ar);
+
+			ar = org.cloudfoundry.client.v3.applications.ApplicationResource.builder()
+																			.name("testapp2").state(ApplicationState.STARTED)
+																			.createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP2_UUID)
+																			.build();
+			list.add(ar);
+
+			ar = org.cloudfoundry.client.v3.applications.ApplicationResource.builder()
+																			.name("internalapp").state(ApplicationState.STARTED)
+																			.createdAt(CREATED_AT_TIMESTAMP).id(UNITTEST_APP_INTERNAL_UUID)
+																			.build();
+			list.add(ar);
+
+			org.cloudfoundry.client.v3.applications.ListApplicationsResponse resp = org.cloudfoundry.client.v3.applications.ListApplicationsResponse
+				.builder().addAllResources(list).build();
+			return Mono.just(resp);
+		}
+		else if (UNITTEST_SPACE_UUID_DOESNOTEXIST.equals(spaceId)) {
+			return Mono.just(org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder().build());
+		}
+		else if (UNITTEST_SPACE_UUID_EXCEPTION.equals(spaceId)) {
+			return Mono.just(org.cloudfoundry.client.v3.applications.ListApplicationsResponse.builder().build()).map(x -> {
+				throw new Error("exception on AllAppIdsInSpace");
+			});
+		}
+
+		Assertions.fail("Invalid process request");
+		return null;
+	}
+
+	@Override
+	public Mono<GetSpaceResponse> retrieveSpaceV3(String spaceId) {
+		// This API has drastically changed in v3 and does not support the same resources. This call for a space summary will probably
+		// take another call to list applications for a space, list routes for the apps, and list domains in the org
+		// Previously they were all grouped into this API
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse> retrieveAllDomainsV3(String orgId) {
+		List<org.cloudfoundry.client.v3.domains.DomainResource> domains = new ArrayList<>();
+		org.cloudfoundry.client.v3.domains.DomainResource domain = org.cloudfoundry.client.v3.domains.DomainResource.builder()
+																													.name(UNITTEST_INTERNAL_DOMAIN)
+																													.isInternal(true)
+																													.id(UNITTEST_INTERNAL_DOMAIN_UUID)
+																													.createdAt(CREATED_AT_TIMESTAMP)
+																													.build();
+
+		domains.add(domain);
+
+		domain = org.cloudfoundry.client.v3.domains.DomainResource.builder()
+																  .name(UNITTEST_SHARED_DOMAIN)
+																  .isInternal(false)
+																  .id(UNITTEST_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP)
+																  .build();
+
+		domains.add(domain);
+
+		domain = org.cloudfoundry.client.v3.domains.DomainResource.builder()
+																  .name(UNITTEST_ADDITIONAL_SHARED_DOMAIN)
+																  .isInternal(false)
+																  .id(UNITTEST_ADDITIONAL_SHARED_DOMAIN_UUID).createdAt(CREATED_AT_TIMESTAMP)
+																  .build();
+
+		domains.add(domain);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse response = org.cloudfoundry.client.v3.organizations.ListOrganizationDomainsResponse
+			.builder().addAllResources(domains).build();
+		return Mono.just(response);
+	}
+
+	@Override
+	public Mono<ListApplicationRoutesResponse> retrieveRoutesForAppId(String appId) {
+		throw new UnsupportedOperationException();
+	}
+
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorMock.java
@@ -493,4 +493,9 @@ public class CFAccessorMock implements CFAccessor {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
+	public boolean isV3Enabled() {
+		return true;
+	}
+
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulatorTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulatorTest.java
@@ -89,4 +89,40 @@ class CFAccessorSimulatorTest {
 		Assertions.assertTrue(sharedDomain.getEntity().getInternal());
 		Assertions.assertEquals(CFAccessorSimulator.INTERNAL_DOMAIN, sharedDomain.getEntity().getName());
 	}
+
+	@Test
+	void testRetrieveOrgIdV3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveOrgId("simorg"));
+	}
+
+	@Test
+	void testRetrieveSpaceIdV3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveSpaceIdV3(CFAccessorSimulator.ORG_UUID, "simspace"));
+	}
+
+	@Test
+	void testRetrieveAllDomainsV3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveAllDomainsV3(CFAccessorSimulator.ORG_UUID));
+	}
+
+	@Test
+	void testRetrieveRoutes3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveRoutesForAppId("simapp"));
+	}
+
+	@Test
+	void testRetrieveAllSpacesV3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveSpaceIdsInOrgV3(CFAccessorSimulator.ORG_UUID));
+	}
+
+	@Test
+	void testRetrieveSpaceV3() {
+		CFAccessorSimulator subject = new CFAccessorSimulator(2);
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveSpaceV3("simspace"));
+	}
 }

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulatorTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/CFAccessorSimulatorTest.java
@@ -93,7 +93,7 @@ class CFAccessorSimulatorTest {
 	@Test
 	void testRetrieveOrgIdV3() {
 		CFAccessorSimulator subject = new CFAccessorSimulator(2);
-		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveOrgId("simorg"));
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> subject.retrieveOrgIdV3("simorg"));
 	}
 
 	@Test

--- a/src/test/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcherTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/cfaccessor/ReactiveCFPaginatedRequestFetcherTest.java
@@ -7,6 +7,8 @@ import java.util.concurrent.TimeoutException;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsRequest;
 import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
 import org.cloudfoundry.client.v2.organizations.OrganizationResource;
+import org.cloudfoundry.client.v3.Metadata;
+import org.cloudfoundry.client.v3.Pagination;
 import org.cloudfoundry.promregator.internalmetrics.InternalMetrics;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,199 +20,417 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 
 class ReactiveCFPaginatedRequestFetcherTest {
-	
+
 	private InternalMetrics internalMetricsMocked = Mockito.mock(InternalMetrics.class);
-	
+
 	private static PaginatedRequestGeneratorFunction<ListOrganizationsRequest> requestGenerator;
 	private static PaginatedResponseGeneratorFunction<OrganizationResource, ListOrganizationsResponse> responseGenerator;
-	
+	private static PaginatedRequestGeneratorFunctionV3<org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest> requestGeneratorV3;
+	private static PaginatedResponseGeneratorFunctionV3<org.cloudfoundry.client.v3.organizations.OrganizationResource, org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> responseGeneratorV3;
+
 	static {
 		requestGenerator = (orderDirection, resultsPerPage, pageNumber) ->
-				ListOrganizationsRequest.builder()
-				.orderDirection(orderDirection)
-				.resultsPerPage(resultsPerPage)
-				.page(pageNumber)
-				.build();
+			ListOrganizationsRequest.builder()
+									.orderDirection(orderDirection)
+									.resultsPerPage(resultsPerPage)
+									.page(pageNumber)
+									.build();
+
+		requestGeneratorV3 = (resultsPerPage, pageNumber) ->
+			org.cloudfoundry.client.v3.organizations.ListOrganizationsRequest.builder()
+																			 .perPage(resultsPerPage)
+																			 .page(pageNumber)
+																			 .build();
 
 		responseGenerator = (data, numberOfPages) ->
-				ListOrganizationsResponse.builder()
-				.resources(data)
-				.totalPages(numberOfPages)
-				.totalResults(data.size())
-				.build();
+			ListOrganizationsResponse.builder()
+									 .resources(data)
+									 .totalPages(numberOfPages)
+									 .totalResults(data.size())
+									 .build();
+
+		responseGeneratorV3 = (data, numberOfPages) ->
+			org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder()
+																			  .resources(data)
+																			  .pagination(Pagination.builder().totalPages(numberOfPages)
+																									.totalResults(data.size()).build())
+																			  .build();
 
 	}
-	
+
 	@Test
 	void testEmptyResponse() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
-			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
-					.resources(new LinkedList<>())
-					.totalPages(1)
-					.totalResults(0)
-					.build();
-			
-			return Mono.just(response);
-		}, 100, responseGenerator);
-		
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
+				ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+																			  .resources(new LinkedList<>())
+																			  .totalPages(1)
+																			  .totalResults(0)
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGenerator);
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
 		Assertions.assertEquals(1, subjectResponse.getTotalPages().intValue());
 		Assertions.assertEquals(0, subjectResponse.getTotalResults().intValue());
 		Assertions.assertNotNull(subjectResponse.getResources());
-		Assertions.assertTrue (subjectResponse.getResources().isEmpty());
+		Assertions.assertTrue(subjectResponse.getResources().isEmpty());
 	}
-	
+
+	@Test
+	void testEmptyResponseV3() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrievalV3(RequestType.OTHER, "nokey", requestGeneratorV3, request -> {
+				org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse response = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse
+					.builder()
+					.resources(new LinkedList<>())
+					.pagination(Pagination.builder().totalPages(1)
+										  .totalResults(0).build())
+					.build();
+
+				return Mono.just(response);
+			}, 100, responseGeneratorV3);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
+		Assertions.assertEquals(1, subjectResponse.getPagination().getTotalPages().intValue());
+		Assertions.assertEquals(0, subjectResponse.getPagination().getTotalResults().intValue());
+		Assertions.assertNotNull(subjectResponse.getResources());
+		Assertions.assertTrue(subjectResponse.getResources().isEmpty());
+	}
+
 	@Test
 	void testWithContentOnePage() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
-			LinkedList<OrganizationResource> list = new LinkedList<>();
-			list.add(OrganizationResource.builder().build());
-			list.add(OrganizationResource.builder().build());
-			
-			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
-					.resources(list)
-					.totalPages(1)
-					.totalResults(2)
-					.build();
-			
-			return Mono.just(response);
-		}, 100, responseGenerator);
-		
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
+				LinkedList<OrganizationResource> list = new LinkedList<>();
+				list.add(OrganizationResource.builder().build());
+				list.add(OrganizationResource.builder().build());
+
+				ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+																			  .resources(list)
+																			  .totalPages(1)
+																			  .totalResults(2)
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGenerator);
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
 		Assertions.assertEquals(1, subjectResponse.getTotalPages().intValue());
 		Assertions.assertEquals(2, subjectResponse.getTotalResults().intValue());
-		Assertions.assertNotNull (subjectResponse.getResources());
+		Assertions.assertNotNull(subjectResponse.getResources());
 		Assertions.assertEquals(2, subjectResponse.getResources().size());
 	}
-	
+
+	@Test
+	void testWithContentOnePageV3() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrievalV3(RequestType.OTHER, "nokey", requestGeneratorV3, request -> {
+				LinkedList<org.cloudfoundry.client.v3.organizations.OrganizationResource> list = new LinkedList<>();
+				list.add(org.cloudfoundry.client.v3.organizations.OrganizationResource.builder().createdAt("").id("").metadata(Metadata.builder().build()).name("").build());
+				list.add(org.cloudfoundry.client.v3.organizations.OrganizationResource.builder().createdAt("").id("").metadata(Metadata.builder().build()).name("").build());
+
+				org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse response = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder()
+																			  .resources(list)
+																			  .pagination(Pagination.builder().totalPages(1)
+																									.totalResults(0).build())
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGeneratorV3);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
+		Assertions.assertEquals(1, subjectResponse.getPagination().getTotalPages().intValue());
+		Assertions.assertEquals(2, subjectResponse.getPagination().getTotalResults().intValue());
+		Assertions.assertNotNull(subjectResponse.getResources());
+		Assertions.assertEquals(2, subjectResponse.getResources().size());
+	}
+
 	@Test
 	void testWithContentTwoPages() {
 		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, 0, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
-			LinkedList<OrganizationResource> list = new LinkedList<>();
-			
-			for (int i = 0;i<request.getResultsPerPage(); i++) {
-				list.add(OrganizationResource.builder().build());
-			}
-			
-			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
-					.resources(list)
-					.totalPages(2)
-					.totalResults(2 * request.getResultsPerPage())
-					.build();
-			
-			return Mono.just(response);
-		}, 100, responseGenerator);
-		
-		ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
-		Assertions.assertEquals(2, subjectResponse.getTotalPages().intValue());
-		Assertions.assertEquals(2*100, subjectResponse.getTotalResults().intValue());
-		Assertions.assertNotNull(subjectResponse.getResources());
-		Assertions.assertEquals(2*100, subjectResponse.getResources().size());
-	}
-	
-	@Test
-	void testWithContentTwoPagesSecondWithoutItems() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
-			LinkedList<OrganizationResource> list = new LinkedList<>();
-			
-			if (request.getPage() == 1) {
-				for (int i = 0;i<request.getResultsPerPage(); i++) {
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
+				LinkedList<OrganizationResource> list = new LinkedList<>();
+
+				for (int i = 0; i < request.getResultsPerPage(); i++) {
 					list.add(OrganizationResource.builder().build());
 				}
-			}
-			
-			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
-					.resources(list)
-					.totalPages(2)
-					.totalResults( (2 - request.getPage()) * request.getResultsPerPage()) // that's tricky&ugly, but correct: It would be the answer, if suddenly the items on the 2nd page vanished
-					.build();
-			
-			return Mono.just(response);
-		}, 100, responseGenerator);
-		
+
+				ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+																			  .resources(list)
+																			  .totalPages(2)
+																			  .totalResults(2 * request.getResultsPerPage())
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGenerator);
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
 		Assertions.assertEquals(2, subjectResponse.getTotalPages().intValue());
-		Assertions.assertEquals(1*100, subjectResponse.getTotalResults().intValue());
-		Assertions.assertNotNull (subjectResponse.getResources());
-		Assertions.assertEquals(1*100, subjectResponse.getResources().size());
+		Assertions.assertEquals(2 * 100, subjectResponse.getTotalResults().intValue());
+		Assertions.assertNotNull(subjectResponse.getResources());
+		Assertions.assertEquals(2 * 100, subjectResponse.getResources().size());
 	}
-	
+
+	@Test
+	void testWithContentTwoPagesV3() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, 0, Duration.ofMillis(100));
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrievalV3(RequestType.OTHER, "nokey", requestGeneratorV3, request -> {
+				LinkedList<org.cloudfoundry.client.v3.organizations.OrganizationResource> list = new LinkedList<>();
+
+				for (int i = 0; i < request.getPerPage(); i++) {
+					list.add(org.cloudfoundry.client.v3.organizations.OrganizationResource.builder().createdAt("").id("").metadata(Metadata.builder().build()).name("").build());
+				}
+
+				org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse response = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse
+					.builder()
+					.resources(list)
+					.pagination(Pagination.builder().totalPages(2)
+										  .totalResults(2 * request.getPerPage()).build())
+					.build();
+
+				return Mono.just(response);
+			}, 100, responseGeneratorV3);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
+		Assertions.assertEquals(2, subjectResponse.getPagination().getTotalPages().intValue());
+		Assertions.assertEquals(2 * 100, subjectResponse.getPagination().getTotalResults().intValue());
+		Assertions.assertNotNull(subjectResponse.getResources());
+		Assertions.assertEquals(2 * 100, subjectResponse.getResources().size());
+	}
+
+	@Test
+	void testWithContentTwoPagesSecondWithoutItems() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
+				LinkedList<OrganizationResource> list = new LinkedList<>();
+
+				if (request.getPage() == 1) {
+					for (int i = 0; i < request.getResultsPerPage(); i++) {
+						list.add(OrganizationResource.builder().build());
+					}
+				}
+
+				ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+																			  .resources(list)
+																			  .totalPages(2)
+																			  .totalResults((2 - request.getPage()) * request
+																				  .getResultsPerPage()) // that's tricky&ugly, but correct: It would be the answer, if suddenly the items on the 2nd page vanished
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGenerator);
+
+		ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
+		Assertions.assertEquals(2, subjectResponse.getTotalPages().intValue());
+		Assertions.assertEquals(1 * 100, subjectResponse.getTotalResults().intValue());
+		Assertions.assertNotNull(subjectResponse.getResources());
+		Assertions.assertEquals(1 * 100, subjectResponse.getResources().size());
+	}
+
+	@Test
+	void testWithContentTwoPagesSecondWithoutItemsV3() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrievalV3(RequestType.OTHER, "nokey", requestGeneratorV3, request -> {
+				LinkedList<org.cloudfoundry.client.v3.organizations.OrganizationResource> list = new LinkedList<>();
+
+				if (request.getPage() == 1) {
+					for (int i = 0; i < request.getPerPage(); i++) {
+						list.add(org.cloudfoundry.client.v3.organizations.OrganizationResource.builder().createdAt("").id("").metadata(Metadata.builder().build()).name("").build());
+					}
+				}
+
+				org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse response = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse
+					.builder()
+					.resources(list)
+					.pagination(Pagination.builder().totalPages(2)
+										  .totalResults((2 - request.getPerPage()) * request.getPerPage()).build())
+					.build();
+
+				return Mono.just(response);
+			}, 100, responseGeneratorV3);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse subjectResponse = subjectResponseMono.block();
+		Assertions.assertEquals(2, subjectResponse.getPagination().getTotalPages().intValue());
+		Assertions.assertEquals(1 * 100, subjectResponse.getPagination().getTotalResults().intValue());
+		Assertions.assertNotNull(subjectResponse.getResources());
+		Assertions.assertEquals(1 * 100, subjectResponse.getResources().size());
+	}
+
 	@Test
 	void testWithContentTimeoutOnFirstPage() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request ->
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request ->
 				Mono.error(new TimeoutException()), 100, responseGenerator);
-		
+
 		ListOrganizationsResponse fallback = ListOrganizationsResponse.builder().build();
-		
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.doOnError(e ->
-			Assertions.assertTrue(Exceptions.unwrap(e) instanceof TimeoutException)
+																					  Assertions.assertTrue(Exceptions
+																												.unwrap(e) instanceof TimeoutException)
 		).onErrorReturn(fallback).block();
 		Assertions.assertEquals(fallback, subjectResponse);
 	}
-	
+
+	@Test
+	void testWithContentTimeoutOnFirstPageV3() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrievalV3(RequestType.OTHER, "nokey", requestGeneratorV3, request ->
+				Mono.error(new TimeoutException()), 100, responseGeneratorV3);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse fallback = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse
+			.builder().build();
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse subjectResponse = subjectResponseMono.doOnError(e ->
+																															   Assertions
+																																   .assertTrue(Exceptions
+																																				   .unwrap(e) instanceof TimeoutException)
+		).onErrorReturn(fallback).block();
+		Assertions.assertEquals(fallback, subjectResponse);
+	}
+
 	@Test
 	void testWithContentTimeoutOnSecondPage() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
-			if (request.getPage() == 2) {
-				return Mono.error(new TimeoutException());
-			}
-			
-			LinkedList<OrganizationResource> list = new LinkedList<>();
-			
-			if (request.getPage() == 1) {
-				for (int i = 0;i<request.getResultsPerPage(); i++) {
-					list.add(OrganizationResource.builder().build());
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request -> {
+				if (request.getPage() == 2) {
+					return Mono.error(new TimeoutException());
 				}
-			}
-			
-			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
-					.resources(list)
-					.totalPages(2)
-					.totalResults(2 * request.getResultsPerPage()) 
-					.build();
-			
-			return Mono.just(response);
-		}, 100, responseGenerator);
-		
+
+				LinkedList<OrganizationResource> list = new LinkedList<>();
+
+				if (request.getPage() == 1) {
+					for (int i = 0; i < request.getResultsPerPage(); i++) {
+						list.add(OrganizationResource.builder().build());
+					}
+				}
+
+				ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+																			  .resources(list)
+																			  .totalPages(2)
+																			  .totalResults(2 * request.getResultsPerPage())
+																			  .build();
+
+				return Mono.just(response);
+			}, 100, responseGenerator);
+
 		ListOrganizationsResponse fallback = ListOrganizationsResponse.builder().build();
-		
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.doOnError(e ->
-			Assertions.assertTrue(Exceptions.unwrap(e) instanceof TimeoutException)
+																					  Assertions.assertTrue(Exceptions
+																												.unwrap(e) instanceof TimeoutException)
+		).onErrorReturn(fallback).block();
+		Assertions.assertEquals(fallback, subjectResponse);
+	}
+
+	@Test
+	void testWithContentTimeoutOnSecondPageV3() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrievalV3(RequestType.OTHER, "nokey", requestGeneratorV3, request -> {
+				if (request.getPage() == 2) {
+					return Mono.error(new TimeoutException());
+				}
+
+				LinkedList<org.cloudfoundry.client.v3.organizations.OrganizationResource> list = new LinkedList<>();
+
+				if (request.getPage() == 1) {
+					for (int i = 0; i < request.getPerPage(); i++) {
+						list.add(org.cloudfoundry.client.v3.organizations.OrganizationResource.builder().createdAt("").id("").metadata(Metadata.builder().build()).name("").build());
+					}
+				}
+
+				org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse response = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse
+					.builder()
+					.resources(list)
+				.pagination(Pagination.builder().totalPages(2)
+									 .totalResults(2 * request.getPerPage()).build())
+					.build();
+
+				return Mono.just(response);
+			}, 100, responseGeneratorV3);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse fallback = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder().build();
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse subjectResponse = subjectResponseMono.doOnError(e ->
+																					  Assertions.assertTrue(Exceptions
+																												.unwrap(e) instanceof TimeoutException)
 		).onErrorReturn(fallback).block();
 		Assertions.assertEquals(fallback, subjectResponse);
 	}
 
 	@Test
 	void testWithContentGeneralException() {
-		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration.ofMillis(100));
-		
-		Mono<ListOrganizationsResponse> subjectResponseMono = subject.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request ->
-			Mono.error(new Exception()), 100, responseGenerator);
-		
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrieval(RequestType.OTHER, "nokey", requestGenerator, request ->
+				Mono.error(new Exception()), 100, responseGenerator);
+
 		ListOrganizationsResponse fallback = ListOrganizationsResponse.builder().build();
-		
+
 		ListOrganizationsResponse subjectResponse = subjectResponseMono.doOnError(e ->
-			Assertions.assertTrue(Exceptions.unwrap(e) instanceof Exception)
+																					  Assertions.assertTrue(Exceptions.unwrap(e) instanceof Exception)
 		).onErrorReturn(fallback).block();
 		Assertions.assertEquals(fallback, subjectResponse);
 	}
-	
+
+	@Test
+	void testWithContentGeneralExceptionV3() {
+		ReactiveCFPaginatedRequestFetcher subject = new ReactiveCFPaginatedRequestFetcher(this.internalMetricsMocked, Double.MAX_VALUE, Duration
+			.ofMillis(100));
+
+		Mono<org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse> subjectResponseMono = subject
+			.performGenericPagedRetrievalV3(RequestType.OTHER, "nokey", requestGeneratorV3, request ->
+				Mono.error(new Exception()), 100, responseGeneratorV3);
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse fallback = org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse.builder().build();
+
+		org.cloudfoundry.client.v3.organizations.ListOrganizationsResponse subjectResponse = subjectResponseMono.doOnError(e ->
+																					  Assertions.assertTrue(Exceptions.unwrap(e) instanceof Exception)
+		).onErrorReturn(fallback).block();
+		Assertions.assertEquals(fallback, subjectResponse);
+	}
+
 	@Test
 	void testInfiniteRateLimitPossible() {
 		RateLimiter rl = RateLimiter.create(Double.POSITIVE_INFINITY);
-		
+
 		boolean acquired = rl.tryAcquire(10000, Duration.ofMillis(100));
 		Assertions.assertTrue(acquired);
 	}

--- a/src/test/java/org/cloudfoundry/promregator/config/ConfigurationValidationsTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/config/ConfigurationValidationsTest.java
@@ -4,6 +4,9 @@ import org.cloudfoundry.promregator.config.validations.ConfigurationValidation;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.List;
+
 class ConfigurationValidationsTest {
 	private class TestableConfigurationValidations extends ConfigurationValidations {
 		public boolean called = false;
@@ -38,9 +41,7 @@ class ConfigurationValidationsTest {
 	@Test
 	void testNoValidationFailed() {
 		TestableConfigurationValidations subject = new TestableConfigurationValidations();
-		ConfigurationValidation[] listOfValidations = {
-				new AcceptingConfigurationValidation()
-		};
+		List<ConfigurationValidation> listOfValidations = Collections.singletonList(new AcceptingConfigurationValidation());
 		subject.listOfValidations = listOfValidations;
 		
 		subject.validateConfiguration();
@@ -51,9 +52,7 @@ class ConfigurationValidationsTest {
 	@Test
 	void testValidationFailed() {
 		TestableConfigurationValidations subject = new TestableConfigurationValidations();
-		ConfigurationValidation[] listOfValidations = {
-				new FailingConfigurationValidation()
-		};
+		List<ConfigurationValidation> listOfValidations = Collections.singletonList(new FailingConfigurationValidation());
 		subject.listOfValidations = listOfValidations;
 		
 		subject.validateConfiguration();

--- a/src/test/java/org/cloudfoundry/promregator/config/validations/CompatibleCAPIVersionTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/config/validations/CompatibleCAPIVersionTest.java
@@ -1,0 +1,80 @@
+package org.cloudfoundry.promregator.config.validations;
+
+import org.cloudfoundry.promregator.cfaccessor.CFAccessor;
+import org.cloudfoundry.promregator.config.PromregatorConfiguration;
+import org.cloudfoundry.promregator.config.Target;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+class CompatibleCAPIVersionTest {
+	@InjectMocks
+	private CompatibleCAPIVersion subject;
+
+	@Mock
+	private CFAccessor cfAccessorMock;
+
+	@BeforeEach
+	public void initMocks(){
+		MockitoAnnotations.openMocks(this);
+	}
+
+	@Test
+	void testValidateConfigNoV3() {
+		Target t = new Target();
+		t.setKubernetesAnnotations(true);
+
+		List<Target> targets = new LinkedList<>();
+		targets.add(t);
+
+		PromregatorConfiguration pc = new PromregatorConfiguration();
+		pc.setTargets(targets);
+
+		when(this.cfAccessorMock.isV3Enabled()).thenReturn(false);
+		String result = subject.validate(pc);
+
+		Assertions.assertNotNull(result);
+	}
+
+	@Test
+	void testValidateConfigNoV3NoKubernetes() {
+		Target t = new Target();
+		t.setKubernetesAnnotations(false);
+
+		List<Target> targets = new LinkedList<>();
+		targets.add(t);
+
+		PromregatorConfiguration pc = new PromregatorConfiguration();
+		pc.setTargets(targets);
+
+		when(this.cfAccessorMock.isV3Enabled()).thenReturn(false);
+		String result = subject.validate(pc);
+
+		Assertions.assertNull(result);
+	}
+
+	@Test
+	void testValidateConfigOk() {
+		Target t = new Target();
+		t.setKubernetesAnnotations(true);
+
+		List<Target> targets = new LinkedList<>();
+		targets.add(t);
+
+		PromregatorConfiguration pc = new PromregatorConfiguration();
+		pc.setTargets(targets);
+
+		when(this.cfAccessorMock.isV3Enabled()).thenReturn(true);
+		String result = subject.validate(pc);
+
+		Assertions.assertNull(result);
+	}
+}

--- a/src/test/java/org/cloudfoundry/promregator/scanner/ResolvedTargetTest.java
+++ b/src/test/java/org/cloudfoundry/promregator/scanner/ResolvedTargetTest.java
@@ -15,6 +15,7 @@ class ResolvedTargetTest {
 		
 		subject.setPath("/path/test");
 		subject.setProtocol("https");
+		subject.setKubernetesAnnotations(true);
 		
 		String answer = subject.toString();
 		
@@ -23,6 +24,7 @@ class ResolvedTargetTest {
 		Assertions.assertTrue(answer.contains("testapp"));
 		Assertions.assertTrue(answer.contains("/path/test"));
 		Assertions.assertTrue(answer.contains("https"));
+		Assertions.assertTrue(answer.contains("kuberntesAnnotations=true"));
 	}
 
 }


### PR DESCRIPTION
## Current Situation
Right now you have to specifically opt in an entire org/space, or individually pick apps as targets/regex match their names. With the additions of annotations and labels in V3 CAPI APIs, it makes more sense to let developers opt their applications in without modifying the promregator configuration.

## Solution Approach
This solution strictly follows what the CloudFoundry Foundation does for CF-for-k8s, adding the same sort of support to CF-for-VMs. For information on how cf-for-k8s handles this see [here](https://github.com/cloudfoundry/cf-for-k8s-metric-examples).

Basically the idea is any application can opt into metrics with the following:
```yaml
---
applications:
- name: go-app-with-metrics
  health-check-type: process
  instances: 2
  metadata:
    annotations:
      prometheus.io/scrape: "true"
      prometheus.io/port: "2112"
      prometheus.io/path: "/metrics"
```

These standard Kubernetes annotations enable scraping. 

In this PR I have implemented the following:
- Stubbed out replacements for all the V2 API calls. Moving to V3 in the future should be simplier now
- I added the V3 APIs to the CFAccessor interface instead of a V3 specific interface. This makes it easier to implement and follows along with what the CF Java Client already does (tacking `<methodname>V3` to their V3 endpoints)
- I've added a new configuration parameter to the targets listing called `kubernetesAnnotations`. Enabling this feature will still first apply all the other target matching before finally checking for the standard Kubernetes annotations on the app.
- If kubernetes annotations is enabled but V3 API support is not detected on the foundation, it is silently ignored with an warning log output
- If the developer specified the `prometheus.io/path`, Promregator will use this metrics path for this specific app. This allows every app to specify their own metrics pathing without updating the promregator configuration
- Currently `prometheus.io/port` is ignored. I have documented this.
- If kubernetes annotations is enabled and the `prometheus.io/scrape` does not equal `"true"` the application will not be scraped or output in the `/discovery` calls.
- A small tweak was made to the `HttpClient` constructed for the proxy calls to use the system client. This allows users to provide their own SSL Context on the JVM command line and gives Promregator mTLS support for free. This change is backwards compatible.

Example config:
```yaml
  targets:
    - orgName: test-org
      kubernetesAnnotations: true
```

One issue I noticed unrelated to these changes:
- During tests I had intermittent failures of `CFAccessorCacheClassicTest`. I dug into this and it seems like in `AutoRefreshingCacheMap` another thread is encountering a race condition where cache is added to `new EntryProperties` but before another call can be made by the test, the refresh thread clears it because it is not marked as "recently used" yet. This causes the test to pass sometimes and fail others.