### PR TITLE
publish library jar in addition to executable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,9 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+		                <configuration>
+                                        <classifier>exec</classifier>
+                              </configuration>
 			</plugin>
 
 			<!-- see also https://central.sonatype.org/pages/apache-maven.html -->


### PR DESCRIPTION
## Current Situation
Promregator is released as a single executable jar.

## Problem Statement
Executable jars cannot be easily extended without changing the underlying codebase.

## Solution Approach
Use spring-boot-maven-plugin classifier to cause an "exec" jar to be generated as well as standard library jar.

## Prerequisites
Consider impacts - alternatives are available depending on how the resulting jar files should be made available.
