### PR TITLE
bugfix: NPE when there is an application with no routes

### DIFF
--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
@@ -251,7 +251,9 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				// Set the access url to the selected route (without any protocol or path yet)
 				v.setAccessURL(this.determineApplicationRoute(urls,
 						v.getTarget().getOriginalTarget().getPreferredRouteRegexPatterns()));
-			}
+			} else
+				// if there is no url, skip this one
+				return Mono.empty();
 
 			// In the interest of backwards compatibility lest do this inside a try.
 			// There is little reason why this should not find the correct domain
@@ -274,7 +276,7 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 			OSAVector v = tuple.getT1();
 			List<DomainResource> domains = tuple.getT2();
 
-			if (domains.size() == 0) {
+			if (domains.size() == 0 || v.getDomainId() == null) {
 				// NB: This drops the current target!
 				return Mono.empty();
 			}

--- a/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
+++ b/src/main/java/org/cloudfoundry/promregator/scanner/ReactiveAppInstanceScanner.java
@@ -251,9 +251,10 @@ public class ReactiveAppInstanceScanner implements AppInstanceScanner {
 				// Set the access url to the selected route (without any protocol or path yet)
 				v.setAccessURL(this.determineApplicationRoute(urls,
 						v.getTarget().getOriginalTarget().getPreferredRouteRegexPatterns()));
-			} else
+			} else {
 				// if there is no url, skip this one
 				return Mono.empty();
+			}
 
 			// In the interest of backwards compatibility lest do this inside a try.
 			// There is little reason why this should not find the correct domain


### PR DESCRIPTION
## Current Situation
If there is a running app which does not have any routes bound to it, we get a NPE.

## Problem Statement
In this case, the whole monitoring is stopped as it is not recoverable and promregator does not do anything.

## Solution Approach
If there are no urls, ignore the application


## Symptom
``` 
java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because the return value of "org.cloudfoundry.promregator.scanner.ReactiveAppInstanceScanner$OSAVector.getDomainId()" is null
	at org.cloudfoundry.promregator.scanner.ReactiveAppInstanceScanner.lambda$10(ReactiveAppInstanceScanner.java:284) ~[classes/:na]
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.onNext(FluxFlatMap.java:386) ~[reactor-core-3.4.5.jar:3.4.5]
	at reactor.core.publisher.FluxZip$ZipCoordinator.drain(FluxZip.java:756) ~[reactor-core-3.4.5.jar:3.4.5]
	at reactor.core.publisher.FluxZip$ZipInner.onNext(FluxZip.java:915) ~[reactor-core-3.4.5.jar:3.4.5]
	at reactor.core.publisher.FluxMergeSequential$MergeSequentialMain.drain(FluxMergeSequential.java:432) ~[reactor-core-3.4.5.jar:3.4.5]
```
