### PR TITLE
Bumping spring-boot version to 2.4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.10</version> <!-- see also https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
+		<version>2.4.13</version> <!-- see also https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
 		<!-- Warning! On bumping also check guava-version below! -->
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>


### PR DESCRIPTION
## Current Situation
We are using spring-boot 2.4.10.

## Problem Statement
There are component version used which have two known CVEs: 
* CVE-2021-42340
* CVE-2021-22096

## Solution Approach
We are bumping to spring-boot 2.4.13 (most recent version available).

## Note
There is no analysis/verification that earlier versions of promregator are really vulnerable to these threats. Bumping took place out of sanity and common sense reasons.
