### PR TITLE
Bump Spring-Boot to 2.5.7 and Upgrade CloudFoundry Client to 5.6.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,18 +43,24 @@ def springCloudCliPasswordTest(params) {
 	assert params.currentVersion != null : "Current Version at springCloudCliPasswordTest not set"
 
 	dir("../springCloudTest") {
+		# for most recent version look at https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/
+		def springBootCLIVersion = "2.5.7"
+		
+		# For most recent version see also https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-cli
+		def springCloudCLIVersion = "2.2.4.RELEASE"
+	
 		sh """
-			wget -nv https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/2.5.4/spring-boot-cli-2.5.4-bin.tar.gz
-			tar xzvf spring-boot-cli-2.5.4-bin.tar.gz
-			rm -f spring-boot-cli-2.5.4-bin.tar.gz
-			cd spring-2.5.4/bin
+			wget -nv https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/${springBootCLIVersion}/spring-boot-cli-${springBootCLIVersion}-bin.tar.gz
+			tar xzvf spring-boot-cli-${springBootCLIVersion}-bin.tar.gz
+			rm -f spring-boot-cli-${springBootCLIVersion}-bin.tar.gz
+			cd spring-${springBootCLIVersion}/bin
 			
-			./spring install org.springframework.cloud:spring-cloud-cli:2.2.4.RELEASE
+			./spring install org.springframework.cloud:spring-cloud-cli:${springCloudCLIVersion}
 		"""
 		
 		withCredentials([usernamePassword(credentialsId: 'bluemix-ibm-cf-platform', passwordVariable: 'CFPASSWORD', usernameVariable: 'CFUSER')]) {
 			sh """#!/bin/bash -xe
-				spring-2.5.4/bin/spring encrypt '${CFPASSWORD}' --key somekey > encrypted.txt
+				spring-${springBootCLIVersion}/bin/spring encrypt '${CFPASSWORD}' --key somekey > encrypted.txt
 				
 			"""
 		}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,10 +43,10 @@ def springCloudCliPasswordTest(params) {
 	assert params.currentVersion != null : "Current Version at springCloudCliPasswordTest not set"
 
 	dir("../springCloudTest") {
-		# for most recent version look at https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/
+		// For most recent version look at https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/
 		def springBootCLIVersion = "2.5.7"
 		
-		# For most recent version see also https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-cli
+		// For most recent version see also https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-cli
 		def springCloudCLIVersion = "2.2.4.RELEASE"
 	
 		sh """

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.0</version> <!-- see also https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
+		<version>2.5.7</version> <!-- see also https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
 		<!-- Warning! On bumping also check guava-version below! -->
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>2.5.7</version> <!-- see also https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
 		<!-- Warning! On bumping also check guava-version below! -->
+		<!-- Note! If you bump this version here, also check the spring-boot CLI version 
+		in our integration tests (see Jenkinsfile) -->
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.13</version> <!-- see also https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
+		<version>2.6.0</version> <!-- see also https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
 		<!-- Warning! On bumping also check guava-version below! -->
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,11 @@
 		  
 		  Further impact assessment especially on the second topic is needed
 		 -->
-		<cloudfoundry.client.version>4.16.0.RELEASE</cloudfoundry.client.version>
+
+		<!-- https://mvnrepository.com/artifact/org.cloudfoundry/cloudfoundry-client-reactor -->
+		<cloudfoundry.client.version>5.6.0.RELEASE</cloudfoundry.client.version>
+		<!-- see also https://github.com/cloudfoundry/cf-java-client -->
+		
 		<logback.contrib.version>0.1.5</logback.contrib.version>
 
 		<sonar.projectKey>promregator</sonar.projectKey>


### PR DESCRIPTION
## Current Situation
We are on the outdated spring-boot release 2.4.x

## Problem Statement
There are security findings of CVEs due to old versions used by spring-boot 2.4.x which seem hard to patch.

## Solution Approach
Bump spring-boot to the most current version of release 2.5.x

## Prerequisites
spring-boot 2.6.0 is already available, but we are lacking support for spring cloud there yet.
