### PR TITLE
Add kotlin configuration and initial Kotlin file to demonstrate it is working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,38 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib-jdk8</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-reactor</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-jdk8</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-reactive</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-coroutines-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.github.microutils</groupId>
+			<artifactId>kotlin-logging-jvm</artifactId>
+			<version>2.0.11</version>
+		</dependency>
+
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 		</dependency>
@@ -356,6 +388,89 @@
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+
+			<plugin>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<version>${kotlin.version}</version>
+				<configuration>
+					<args>
+						<arg>-Xjsr305=strict -Xopt-in=kotlin.RequiresOptIn</arg>
+					</args>
+					<compilerPlugins>
+						<!-- The kotlin-maven-plugin compiled the Kotlin files. The spring/kotlin-maven-allopen sub-plugin makes Spring annotated
+							classes (@Controller, @Service, etc) open (non-final) which is needed by Spring for proxying/APO, etc.
+
+							This is needed since Kotlin makes classes final by default.-->
+
+						<plugin>spring</plugin>
+					</compilerPlugins>
+				</configuration>
+
+				<dependencies>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-allopen</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+								<sourceDir>${project.basedir}/src/main/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-compile</id>
+						<goals> <goal>test-compile</goal> </goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+								<sourceDir>${project.basedir}/src/test/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
+				<executions>
+					<!-- Replacing default-compile as it is treated specially by maven -->
+					<execution>
+						<id>default-compile</id>
+						<phase>none</phase>
+					</execution>
+					<!-- Replacing default-testCompile as it is treated specially by maven -->
+					<execution>
+						<id>default-testCompile</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>java-compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>java-test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>testCompile</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/src/main/java/org/cloudfoundry/promregator/lite/discovery/DiscoveryControllerV2.kt
+++ b/src/main/java/org/cloudfoundry/promregator/lite/discovery/DiscoveryControllerV2.kt
@@ -1,0 +1,55 @@
+package org.cloudfoundry.promregator.lite.discovery
+
+import com.fasterxml.jackson.annotation.JsonGetter
+import com.fasterxml.jackson.annotation.JsonInclude
+import kotlinx.coroutines.runBlocking
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import javax.servlet.http.HttpServletRequest
+
+data class DiscoveryV2Response(
+        val targets: List<String>,
+        val labels: DiscoveryLabelV2,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class DiscoveryLabelV2(
+        @get:JsonGetter("__meta_promregator_target_path") val targetPath: String,
+        @get:JsonGetter("__meta_promregator_target_orgName") val orgName: String? = null,
+        @get:JsonGetter("__meta_promregator_target_spaceName") val spaceName: String? = null,
+        @get:JsonGetter("__meta_promregator_target_applicationName") val applicationName: String? = null,
+        @get:JsonGetter("__meta_promregator_target_applicationId") val applicationId: String? = null,
+        @get:JsonGetter("__meta_promregator_target_instanceNumber") val instanceNumber: String? = null,
+        @get:JsonGetter("__meta_promregator_target_instanceId") val instanceId: String? = null,
+) {
+    @get:JsonGetter("__metrics_path__")
+    val metricsPath: String
+        get() = targetPath
+}
+
+private val log = mu.KotlinLogging.logger {}
+
+@RestController
+class DiscoveryControllerV2(
+//        private val discoveryService: DiscoveryService,
+        @Value("\${promregator.discovery.hostname:#{null}}") private val promHostname: String?,
+        @Value("\${promregator.discovery.port:0}") val promPort: Int,
+        @Value("\${promregator.discovery.ownMetricsEndpoint:true}") private val promregatorMetricsEndpoint: Boolean,
+) {
+
+    @GetMapping("v2/discovery")
+    fun discovery(request: HttpServletRequest,
+                  @RequestParam(required = false, defaultValue = "false") bypassCache: Boolean,
+                  @RequestParam api: String?,
+                  @RequestParam org: String?,
+                  @RequestParam space: String?,
+                  @RequestParam application: String?
+    ): List<DiscoveryV2Response> {
+        return runBlocking {
+            log.warn { "V2 Discovery is incomplete, but callable" }
+            listOf()
+        }
+    }
+}


### PR DESCRIPTION
## Current Situation
This PR is in support of #220 

This PR adds a /v2/discovery endpoint that is written in Kotlin (but not implemented yet) along with the POM changes needed to support Kotlin builds.